### PR TITLE
Remove manual route_modules config note from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,17 +141,6 @@ PR review files go in `dev_docs/pull_requests/{year}/{pr_number}-{slug}/` direct
 - Integration tests tagged `:integration` require PostgreSQL: `createdb phoenix_kit_entities_test`
 - Test helper auto-detects database availability and excludes integration tests if unavailable
 
-## Installation Note
-
-Host apps must register the route module explicitly in config due to compile-time ordering (the router may compile before this dep is discovered):
-
-```elixir
-# config/config.exs
-config :phoenix_kit,
-  route_modules: [PhoenixKitEntities.Routes]
-```
-
-Without this, admin routes (`/admin/entities`, `/admin/settings/entities`, etc.) will return `NoRouteError`.
 
 ## External Dependencies
 


### PR DESCRIPTION
Route discovery is now handled automatically by phoenix_kit's __mix_recompile__?/0 injection. The manual config is documented in phoenix_kit as an optional fallback.