### PR TITLE
Remove misleading Data View override example and tighten routing docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ This module has multiple admin pages, so it uses the **route module pattern** (n
 
 The `admin_tabs/0` callback does NOT have a `live_view:` field — the route module handles all routing.
 
+These routes are auto-discovered by PhoenixKit at compile time and injected into `live_session :phoenix_kit_admin`. Parent apps must never hand-register these routes (or any plugin LiveView routes) in their own `router.ex` — doing so puts the routes in a different `live_session`, which loses the admin layout and crashes the socket on navigation. See `phoenix_kit/guides/custom-admin-pages.md` for the authoritative reference.
+
 ## Tailwind CSS Scanning
 
 This module implements `css_sources/0` returning `[:phoenix_kit_entities]`. PhoenixKit's installer (`mix phoenix_kit.install`) discovers this and adds `@source` directives to the parent's `app.css`. Without this, Tailwind purges CSS classes from our templates.

--- a/lib/phoenix_kit_entities/README.md
+++ b/lib/phoenix_kit_entities/README.md
@@ -36,25 +36,6 @@ All templates follow Phoenix 1.8 layout conventions (`<Layouts.app ...>` with `@
 - Enabling flag: `PhoenixKit.Settings.get_setting("entities_enabled", "false")`.
 - Router: available under `{prefix}/admin/entities/*` via `phoenix_kit_routes()`.
 
-## Customizing the Data View
-
-The admin route `/admin/entities/:entity_slug/data/:id` is handled by
-`PhoenixKitEntities.Web.DataView`. To replace it with your own LiveView,
-declare a route at the same path **before** `phoenix_kit_routes()` in your router:
-
-```elixir
-# In your app's router.ex — MUST be declared before phoenix_kit_routes()
-scope "/phoenix_kit", MyAppWeb do
-  pipe_through [:browser, :phoenix_kit_authenticated]
-  live "/admin/entities/:entity_slug/data/:id", MyCustomDataView, :show
-end
-
-phoenix_kit_routes()
-```
-
-Phoenix matches routes in declaration order, so the custom route wins and
-`DataView` is never reached.
-
 ## Additional Reading
 
 - Overview: `OVERVIEW.md` (in this directory)

--- a/lib/phoenix_kit_entities/web/data_view.ex
+++ b/lib/phoenix_kit_entities/web/data_view.ex
@@ -5,9 +5,6 @@ defmodule PhoenixKitEntities.Web.DataView do
   Uses FormBuilder with disabled fields for the form section.
   """
 
-  # Extension point: declare a route at the same path BEFORE phoenix_kit_routes()
-  # in your router to override this view. See lib/modules/entities/README.md.
-
   use PhoenixKitWeb, :live_view
   on_mount(PhoenixKitEntities.Web.Hooks)
 


### PR DESCRIPTION
The inner lib/phoenix_kit_entities/README.md "Customizing the Data View" section told users to declare a `live "/admin/entities/:entity_slug/data/:id"` route in their parent router BEFORE phoenix_kit_routes() to override the default DataView LiveView. That pattern recreates the exact bug class that motivated this whole pass:

- It pipes through `:phoenix_kit_authenticated` as if it were a plug, but that's a live_session name (from phoenix_kit_authenticated_routes/1 in integration.ex), not a pipeline alias.
- Even with the override routing correctly, the replacement LiveView would sit in a different live_session than :phoenix_kit_admin, so the admin layout would be lost (maybe_apply_plugin_layout/1 only runs inside :phoenix_kit_admin) and cross-session navigation would tear down the socket.

There is no clean alternative for overriding a single route inside an auto-discovered plugin's live_session from the parent router, so delete the section outright rather than leaving it with a caveat. Also remove the dangling comment at the top of web/data_view.ex that referenced the now-deleted README section.

Add a routing auto-discovery paragraph to the top-level AGENTS.md Routing section explaining that admin routes are compiled into :phoenix_kit_admin by compile_external_admin_routes and pointing to phoenix_kit/guides/custom-admin-pages.md for the authoritative reference.