### PR TITLE
Finish entity-definition multilang + add locale-aware public URL helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,17 @@ This is a **library** (not a standalone Phoenix app). It depends on `phoenix_kit
 
 - **`PhoenixKitEntities.Routes`** (`lib/phoenix_kit_entities/routes.ex`) — Admin LiveView routes + public form submission endpoint. Registered via `route_module/0` callback.
 
+- **`PhoenixKitEntities.UrlResolver`** (`lib/phoenix_kit_entities/url_resolver.ex`) — Shared URL-pattern resolution (entity settings → router introspection → per-entity settings → global pattern → fallback). Used by both `SitemapSource` and `EntityData.public_path/3` / `public_url/3`. Settings lookups are wrapped in `try/rescue` so URL generation degrades gracefully when the Settings table is unavailable.
+
+- **`PhoenixKitEntities.SitemapSource`** (`lib/phoenix_kit_entities/sitemap_source.ex`) — `PhoenixKit.Modules.Sitemap.Sources.Source` implementation. Delegates pattern resolution to `UrlResolver` and keeps its own "prefix every language" policy for hreflang-correct sitemap entries.
+
+- **`PhoenixKitEntities.Presence` / `PresenceHelpers`** (`lib/phoenix_kit_entities/presence.ex`, `presence_helpers.ex`) — FIFO collaborative editing locks and presence tracking for the entity/data forms.
+
+- **`PhoenixKitEntities.Mirror.*`** (`lib/phoenix_kit_entities/mirror/`) — Filesystem export/import of entity definitions and data (per-entity toggles in `entity.settings`).
+
 - **`PhoenixKitEntities.Web.*`** (`lib/phoenix_kit_entities/web/`) — Admin LiveViews for entity management. PhoenixKit wraps these in the admin layout automatically.
+
+- **`PhoenixKitEntities.Controllers.EntityFormController`** (`lib/phoenix_kit_entities/controllers/entity_form_controller.ex`) — Handles public form submissions (honeypot, time-based validation, rate limiting).
 
 ### How It Works
 
@@ -69,6 +79,9 @@ This is a **library** (not a standalone Phoenix app). It depends on `phoenix_kit
 - **Entity names** must be snake_case, start with letter, 2-50 chars: `^[a-z][a-z0-9_]*$`
 - **Field definitions** require string keys: `%{"type" => "text", "key" => "name", "label" => "Name"}`
 - **Inline templates** — All LiveView templates use inline `~H` sigils (no separate .heex files) for reliable Tailwind CSS scanning
+- **Multilang for entity metadata** — `display_name`, `display_name_plural`, and `description` are translatable via `entity.settings["translations"]`. Every entity query function (`list_entities`, `get_entity_by_name`, `list_entity_summaries`, …) accepts an optional `lang:` keyword that returns the struct with those fields resolved. Admin LiveViews thread `lang: @current_locale` to dogfood the pattern; `Web.EntityForm` and `Web.EntitiesSettings` intentionally keep raw primary-language reads because they manage canonical identity.
+- **Sidebar locale propagation** — `entities_children/1` has no direct access to the current locale from the dashboard registry, so it reads `Gettext.get_locale(PhoenixKitWeb.Gettext)` at render time. The ETS cache is keyed by `{@entities_cache_key, locale}`; `invalidate_entities_cache/0` uses `:ets.match_delete/2` to clear every locale variant on mutations.
+- **Public URL helpers** — `EntityData.public_path/3` and `public_url/3` build locale-aware public URLs for records, reusing `UrlResolver`. Locale policy matches `PhoenixKit.Utils.Routes.path/2`: `nil` locale / single-language / primary language → no prefix; other locales → `/<base>/…`. See README "Public URL resolution" for the full resolution chain.
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -269,17 +269,143 @@ Admin routes are registered via `PhoenixKitEntities.Routes` (returned by `route_
 
 ## Multi-language support
 
-Multilang is auto-enabled when PhoenixKit has 2+ languages configured. Data is stored in a nested JSONB structure:
+Multilang is auto-enabled when PhoenixKit has 2+ languages configured. Both the entity definition (labels/description) and each data record support translations.
+
+### Entity definition translations
+
+Translatable fields: `display_name`, `display_name_plural`, `description`.
+
+Storage: `entity.settings["translations"]` JSONB.
 
 ```elixir
-# Multilang data format
 %{
-  "en" => %{"title" => "Hello", "description" => "..."},
-  "es" => %{"title" => "Hola", "description" => "..."}
+  "translations" => %{
+    "es-ES" => %{
+      "display_name" => "Producto",
+      "display_name_plural" => "Productos",
+      "description" => "Catálogo de productos"
+    }
+  }
 }
 ```
 
-See `PhoenixKit.Utils.Multilang` for helper functions.
+Only fields that differ from the primary language need to be stored — missing keys fall back to the primary column value on read.
+
+**Editing (admin UI):** the entity create/edit form renders language tabs above the translatable fields. No opt-in required — tabs appear automatically when the Languages module has 2+ languages.
+
+**API:**
+
+```elixir
+alias PhoenixKitEntities, as: Entities
+
+# Read
+Entities.get_entity_translations(entity)
+# => %{"es-ES" => %{"display_name" => "Producto", ...}}
+
+Entities.get_entity_translation(entity, "es-ES")
+# => %{"display_name" => "Producto", "display_name_plural" => "Productos", ...}
+
+# Write (empty string removes a per-field override)
+Entities.set_entity_translation(entity, "es-ES", %{"display_name" => "Producto"})
+
+# Remove all translations for a language
+Entities.remove_entity_translation(entity, "es-ES")
+```
+
+### Reading translated metadata
+
+Every query function accepts an optional `lang:` keyword. When provided, the returned struct has `display_name` / `display_name_plural` / `description` resolved to that locale (missing fields fall back to primary):
+
+```elixir
+Entities.list_entities(lang: "es-ES")
+Entities.list_active_entities(lang: "es-ES")
+Entities.get_entity(uuid, lang: "es-ES")
+Entities.get_entity!(uuid, lang: "es-ES")
+Entities.get_entity_by_name("product", lang: "es-ES")
+Entities.list_entity_summaries(lang: "es-ES")  # sidebar/navigation summaries
+```
+
+Without `lang:`, raw primary-language column values are returned (backward compatible).
+
+Manual resolution is also available:
+
+```elixir
+resolved = Entities.resolve_language(entity, "es-ES")
+resolved_list = Entities.resolve_languages(entities, "es-ES")
+```
+
+### Data record translations
+
+Field values inside `entity_data.data` use a nested JSONB structure with a primary-language marker:
+
+```elixir
+%{
+  "_primary_language" => "en-US",
+  "en-US" => %{"_title" => "Hello", "body" => "..."},
+  "es-ES" => %{"_title" => "Hola"}   # overrides only
+}
+```
+
+The `_title` key carries the translated title (the DB `title` column still stores the primary-language title). All `EntityData` query functions accept `lang:` for automatic resolution:
+
+```elixir
+alias PhoenixKitEntities.EntityData
+
+EntityData.get!(uuid, lang: "es-ES")
+EntityData.list_by_entity(entity_uuid, lang: "es-ES")
+EntityData.search_by_title("Hola", entity_uuid, lang: "es-ES")
+EntityData.published_records(entity_uuid, lang: "es-ES")
+EntityData.get_by_slug(entity_uuid, "my-slug", lang: "es-ES")
+```
+
+See `lib/phoenix_kit_entities/OVERVIEW.md` § "Multi-Language Support" for the full translation API (title translations, primary-language changes, compact-mode tabs).
+
+## Public URL resolution
+
+`PhoenixKitEntities.EntityData` exposes locale-aware URL builders for public-facing links (replaces the hand-wired `"/#{record.slug}"` pattern that silently drops locale prefixes on non-default routes).
+
+### Pattern resolution chain
+
+1. `entity.settings["sitemap_url_pattern"]` — per-entity override (e.g. `"/blog/:slug"`)
+2. Router introspection — explicit route (`live "/pages/:slug", ...`) or catchall (`/:entity_name/:slug`)
+3. Per-entity setting `sitemap_entity_<name>_pattern`
+4. Global setting `sitemap_entities_pattern` (with `:entity_name` / `:slug` / `:id` placeholders)
+5. Fallback `/<entity_name>/:slug`
+
+Placeholders: `:slug` (falls back to the record UUID when the slug is nil) and `:id` (the UUID).
+
+### Locale prefix policy
+
+Matches `PhoenixKit.Utils.Routes.path/2`:
+
+- `locale:` omitted or `nil` → no prefix
+- Single-language mode → no prefix
+- Locale matches the primary language → no prefix (default locale served at the unprefixed URL)
+- Other locales → prefixed with the base code (`/es/...`, `/ru/...`)
+
+### Helpers
+
+```elixir
+alias PhoenixKitEntities.EntityData
+
+EntityData.public_path(entity, record)
+# => "/products/my-item"
+
+EntityData.public_path(entity, record, locale: "es-ES")
+# => "/es/products/my-item"
+
+EntityData.public_path(entity, record, locale: "en-US")  # primary language
+# => "/products/my-item"
+
+EntityData.public_url(entity, record, base_url: "https://shop.example.com")
+# => "https://shop.example.com/products/my-item"
+
+# Batch usage — pre-build the routes cache once
+cache = PhoenixKitEntities.UrlResolver.build_routes_cache()
+Enum.map(records, &EntityData.public_path(entity, &1, locale: locale, routes_cache: cache))
+```
+
+If `:base_url` is omitted, `public_url/3` falls back to the `site_url` setting.
 
 ## Public forms
 

--- a/guides/entities-guide.md
+++ b/guides/entities-guide.md
@@ -17,6 +17,8 @@ The Entities system lets you create custom content types (like blog posts, produ
 7. [Public Forms](#public-forms)
 8. [API Reference](#api-reference)
 9. [Common Patterns](#common-patterns)
+10. [Multi-Language Support](#multi-language-support)
+11. [Public URL Resolution](#public-url-resolution)
 
 ---
 
@@ -24,11 +26,11 @@ The Entities system lets you create custom content types (like blog posts, produ
 
 ```elixir
 # 1. Enable the Entities system
-PhoenixKit.Modules.Entities.enable_system()
+PhoenixKitEntities.enable_system()
 
 # 2. Create an entity
-alias PhoenixKit.Modules.Entities
-alias PhoenixKit.Modules.Entities.FieldTypes
+alias PhoenixKitEntities
+alias PhoenixKitEntities.FieldTypes
 
 {:ok, entity} = Entities.create_entity(%{
   name: "contact_form",
@@ -42,7 +44,7 @@ alias PhoenixKit.Modules.Entities.FieldTypes
 })
 
 # 3. Create data records
-{:ok, record} = PhoenixKit.Modules.Entities.EntityData.create(%{
+{:ok, record} = PhoenixKitEntities.EntityData.create(%{
   entity_uuid: entity.uuid,
   title: "New Submission",
   status: "published",
@@ -61,7 +63,7 @@ alias PhoenixKit.Modules.Entities.FieldTypes
 ### Via Code
 
 ```elixir
-PhoenixKit.Modules.Entities.enable_system()
+PhoenixKitEntities.enable_system()
 ```
 
 ### Via Admin UI
@@ -75,7 +77,7 @@ Visit `/phoenix_kit/admin/modules` and enable the Entities module.
 ### Basic Entity
 
 ```elixir
-{:ok, entity} = PhoenixKit.Modules.Entities.create_entity(%{
+{:ok, entity} = PhoenixKitEntities.create_entity(%{
   name: "article",
   display_name: "Article",
   display_name_plural: "Articles",
@@ -96,7 +98,7 @@ Visit `/phoenix_kit/admin/modules` and enable the Entities module.
 
 ```elixir
 # Note: created_by_uuid is optional - it auto-fills with first admin user if not provided
-{:ok, entity} = PhoenixKit.Modules.Entities.create_entity(%{
+{:ok, entity} = PhoenixKitEntities.create_entity(%{
   name: "product",
   display_name: "Product",
   status: "published",
@@ -172,7 +174,7 @@ admin = PhoenixKit.Users.Auth.get_first_admin()
 Use these helpers to create field definitions more easily:
 
 ```elixir
-alias PhoenixKit.Modules.Entities.FieldTypes
+alias PhoenixKitEntities.FieldTypes
 
 # Text fields
 FieldTypes.text_field("name", "Full Name", required: true)
@@ -208,8 +210,8 @@ FieldTypes.new_field("select", "status", "Status", options: ["Active", "Inactive
 ### Creating Entity with Choice Fields
 
 ```elixir
-alias PhoenixKit.Modules.Entities
-alias PhoenixKit.Modules.Entities.FieldTypes
+alias PhoenixKitEntities
+alias PhoenixKitEntities.FieldTypes
 
 {:ok, entity} = Entities.create_entity(%{
   name: "survey_response",
@@ -241,7 +243,7 @@ alias PhoenixKit.Modules.Entities.FieldTypes
 ### Create a Data Record
 
 ```elixir
-{:ok, record} = PhoenixKit.Modules.Entities.EntityData.create(%{
+{:ok, record} = PhoenixKitEntities.EntityData.create(%{
   entity_uuid: entity.uuid,
   title: "New Contact",
   status: "published",
@@ -258,35 +260,35 @@ alias PhoenixKit.Modules.Entities.FieldTypes
 
 ```elixir
 # All records for an entity
-records = PhoenixKit.Modules.Entities.EntityData.list_by_entity(entity.uuid)
+records = PhoenixKitEntities.EntityData.list_by_entity(entity.uuid)
 
 # Search by title (search_term first, entity_uuid optional second)
-results = PhoenixKit.Modules.Entities.EntityData.search_by_title("John", entity.uuid)
+results = PhoenixKitEntities.EntityData.search_by_title("John", entity.uuid)
 
 # Get entity by name
-entity = PhoenixKit.Modules.Entities.get_entity_by_name("contact_form")
+entity = PhoenixKitEntities.get_entity_by_name("contact_form")
 
 # Get by UUID
-record = PhoenixKit.Modules.Entities.EntityData.get(record_uuid)
+record = PhoenixKitEntities.EntityData.get(record_uuid)
 
 # Filter by status
-records = PhoenixKit.Modules.Entities.EntityData.list_by_entity_and_status(entity.uuid, "published")
+records = PhoenixKitEntities.EntityData.list_by_entity_and_status(entity.uuid, "published")
 
 # Get by slug
-record = PhoenixKit.Modules.Entities.EntityData.get_by_slug(entity.uuid, "my-record-slug")
+record = PhoenixKitEntities.EntityData.get_by_slug(entity.uuid, "my-record-slug")
 ```
 
 ### Update and Delete
 
 ```elixir
 # Update
-{:ok, updated} = PhoenixKit.Modules.Entities.EntityData.update(record, %{
+{:ok, updated} = PhoenixKitEntities.EntityData.update(record, %{
   title: "Updated Title",
   data: Map.put(record.data, "new_field", "value")
 })
 
 # Delete
-{:ok, deleted} = PhoenixKit.Modules.Entities.EntityData.delete(record)
+{:ok, deleted} = PhoenixKitEntities.EntityData.delete(record)
 ```
 
 ---
@@ -300,7 +302,7 @@ Embed entity-based forms on public pages for contact forms, surveys, lead captur
 ```elixir
 # Via admin UI: /phoenix_kit/admin/entities/:id/edit
 # Or programmatically:
-PhoenixKit.Modules.Entities.update_entity(entity, %{
+PhoenixKitEntities.update_entity(entity, %{
   settings: %{
     "public_form_enabled" => true,
     "public_form_fields" => ["name", "email", "message"],
@@ -361,42 +363,42 @@ This is handled by `PhoenixKitWeb.EntityFormController`.
 
 ## API Reference
 
-### PhoenixKit.Modules.Entities
+### PhoenixKitEntities
 
 ```elixir
 # Check if system is enabled
-PhoenixKit.Modules.Entities.enabled?() :: boolean()
+PhoenixKitEntities.enabled?() :: boolean()
 
 # Enable/disable
-PhoenixKit.Modules.Entities.enable_system() :: {:ok, Setting.t()}
-PhoenixKit.Modules.Entities.disable_system() :: {:ok, Setting.t()}
+PhoenixKitEntities.enable_system() :: {:ok, Setting.t()}
+PhoenixKitEntities.disable_system() :: {:ok, Setting.t()}
 
 # Get by ID
-PhoenixKit.Modules.Entities.get_entity(id) :: Entity.t() | nil        # Returns nil if not found
-PhoenixKit.Modules.Entities.get_entity!(id) :: Entity.t()             # Raises if not found
-PhoenixKit.Modules.Entities.get_entity_by_name(name) :: Entity.t() | nil
+PhoenixKitEntities.get_entity(id) :: Entity.t() | nil        # Returns nil if not found
+PhoenixKitEntities.get_entity!(id) :: Entity.t()             # Raises if not found
+PhoenixKitEntities.get_entity_by_name(name) :: Entity.t() | nil
 
 # List
-PhoenixKit.Modules.Entities.list_entities() :: [Entity.t()]
-PhoenixKit.Modules.Entities.list_active_entities() :: [Entity.t()]    # Only status: "published"
+PhoenixKitEntities.list_entities() :: [Entity.t()]
+PhoenixKitEntities.list_active_entities() :: [Entity.t()]    # Only status: "published"
 
 # Create/Update/Delete
-PhoenixKit.Modules.Entities.create_entity(attrs) :: {:ok, Entity.t()} | {:error, Changeset.t()}
-PhoenixKit.Modules.Entities.update_entity(entity, attrs) :: {:ok, Entity.t()} | {:error, Changeset.t()}
-PhoenixKit.Modules.Entities.delete_entity(entity) :: {:ok, Entity.t()} | {:error, Changeset.t()}
+PhoenixKitEntities.create_entity(attrs) :: {:ok, Entity.t()} | {:error, Changeset.t()}
+PhoenixKitEntities.update_entity(entity, attrs) :: {:ok, Entity.t()} | {:error, Changeset.t()}
+PhoenixKitEntities.delete_entity(entity) :: {:ok, Entity.t()} | {:error, Changeset.t()}
 
 # Changeset (for forms)
-PhoenixKit.Modules.Entities.change_entity(entity, attrs \\ %{}) :: Changeset.t()
+PhoenixKitEntities.change_entity(entity, attrs \\ %{}) :: Changeset.t()
 
 # Stats
-PhoenixKit.Modules.Entities.get_system_stats() :: %{
+PhoenixKitEntities.get_system_stats() :: %{
   total_entities: integer(),
   active_entities: integer(),
   total_data_records: integer()
 }
 ```
 
-### PhoenixKit.Modules.Entities.EntityData
+### PhoenixKitEntities.EntityData
 
 ```elixir
 # Get by ID
@@ -419,7 +421,7 @@ EntityData.delete(record) :: {:ok, EntityData.t()} | {:error, Changeset.t()}
 EntityData.change(record, attrs \\ %{}) :: Changeset.t()
 ```
 
-### PhoenixKit.Modules.Entities.FieldTypes
+### PhoenixKitEntities.FieldTypes
 
 ```elixir
 # Field builder helpers (recommended for programmatic entity creation)
@@ -458,7 +460,7 @@ FieldTypes.validate_field(field_map) :: {:ok, map()} | {:error, String.t()}
 # In a migration or seeds.exs
 admin = PhoenixKit.Users.Auth.get_user_by_email("admin@example.com")
 
-{:ok, _entity} = PhoenixKit.Modules.Entities.create_entity(%{
+{:ok, _entity} = PhoenixKitEntities.create_entity(%{
   name: "contact",
   display_name: "Contact Submission",
   status: "published",
@@ -484,8 +486,8 @@ admin = PhoenixKit.Users.Auth.get_user_by_email("admin@example.com")
 ### List All Contact Submissions
 
 ```elixir
-entity = PhoenixKit.Modules.Entities.get_entity_by_name("contact")
-submissions = PhoenixKit.Modules.Entities.EntityData.list_by_entity(entity.uuid)
+entity = PhoenixKitEntities.get_entity_by_name("contact")
+submissions = PhoenixKitEntities.EntityData.list_by_entity(entity.uuid)
 
 for submission <- submissions do
   IO.puts("#{submission.data["name"]} - #{submission.data["email"]}")
@@ -495,8 +497,8 @@ end
 ### Export Entity Data
 
 ```elixir
-entity = PhoenixKit.Modules.Entities.get_entity_by_name("contact")
-records = PhoenixKit.Modules.Entities.EntityData.list_by_entity(entity.uuid)
+entity = PhoenixKitEntities.get_entity_by_name("contact")
+records = PhoenixKitEntities.EntityData.list_by_entity(entity.uuid)
 
 # Convert to list of maps
 data = Enum.map(records, fn r ->
@@ -513,4 +515,132 @@ Jason.encode!(data)
 
 ---
 
-**Last Updated**: 2026-03-02
+## Multi-Language Support
+
+When PhoenixKit has 2+ languages enabled, entity definitions and data records both support translations.
+
+### Translating Entity Metadata
+
+`display_name`, `display_name_plural`, and `description` are translatable. Translations live in `entity.settings["translations"]` and can be set either through the admin entity form (language tabs appear above the translatable fields) or programmatically:
+
+```elixir
+alias PhoenixKitEntities, as: Entities
+
+{:ok, entity} = Entities.set_entity_translation(entity, "es-ES", %{
+  "display_name" => "Producto",
+  "display_name_plural" => "Productos",
+  "description" => "Catálogo de productos"
+})
+
+# Read a specific translation (merged with primary fallback)
+Entities.get_entity_translation(entity, "es-ES")
+# => %{"display_name" => "Producto", "display_name_plural" => "Productos", ...}
+
+# All translations
+Entities.get_entity_translations(entity)
+# => %{"es-ES" => %{...}, "fr-FR" => %{...}}
+
+# Remove a language
+Entities.remove_entity_translation(entity, "es-ES")
+```
+
+### Reading Translated Metadata in Consumers
+
+Every query function accepts an optional `lang:` keyword. When supplied, the returned struct has translatable fields resolved to that locale (falling back to primary for missing keys):
+
+```elixir
+Entities.list_entities(lang: "es-ES")
+Entities.list_active_entities(lang: "es-ES")
+Entities.get_entity(uuid, lang: "es-ES")
+Entities.get_entity!(uuid, lang: "es-ES")
+Entities.get_entity_by_name("product", lang: "es-ES")
+Entities.list_entity_summaries(lang: "es-ES")
+```
+
+For parent-app listings at `/:locale/...` routes, threading the current locale through `lang:` is the difference between translated and untranslated page titles, breadcrumbs, and `<h1>` content.
+
+### Translating Data Records
+
+Values inside `entity_data.data` use a nested JSONB structure with a primary-language marker:
+
+```elixir
+%{
+  "_primary_language" => "en-US",
+  "en-US" => %{"_title" => "Hello", "body" => "..."},
+  "es-ES" => %{"_title" => "Hola"}   # overrides only
+}
+```
+
+The same `lang:` option works on every `EntityData` query:
+
+```elixir
+alias PhoenixKitEntities.EntityData
+
+EntityData.get!(uuid, lang: "es-ES")
+EntityData.list_by_entity(entity_uuid, lang: "es-ES")
+EntityData.search_by_title("Hola", entity_uuid, lang: "es-ES")
+EntityData.published_records(entity_uuid, lang: "es-ES")
+EntityData.get_by_slug(entity_uuid, "mi-articulo", lang: "es-ES")
+```
+
+---
+
+## Public URL Resolution
+
+Use `EntityData.public_path/3` / `public_url/3` to build locale-aware public links for records. The URL-pattern resolution chain introspects the parent app's router so you don't hand-wire paths per entity.
+
+```elixir
+alias PhoenixKitEntities.EntityData
+
+EntityData.public_path(entity, record)
+# => "/products/my-item"
+
+EntityData.public_path(entity, record, locale: "es-ES")
+# => "/es/products/my-item"   (non-primary locale → base prefix added)
+
+EntityData.public_path(entity, record, locale: "en-US")
+# => "/products/my-item"      (primary locale → no prefix)
+
+EntityData.public_url(entity, record, base_url: "https://shop.example.com")
+# => "https://shop.example.com/products/my-item"
+```
+
+### Pattern resolution chain
+
+1. `entity.settings["sitemap_url_pattern"]` — per-entity override (`"/blog/:slug"`)
+2. Router introspection — explicit (`live "/pages/:slug", ...`) or catchall (`/:entity_name/:slug`)
+3. Per-entity setting `sitemap_entity_<name>_pattern`
+4. Global setting `sitemap_entities_pattern`
+5. Fallback `/<entity_name>/:slug`
+
+Placeholders: `:slug` (falls back to UUID when nil) and `:id` (UUID).
+
+### Translated slugs
+
+When a record has a secondary-language slug override stored as `data[locale]["_slug"]`, `public_path/3` substitutes that override for the `:slug` placeholder:
+
+```elixir
+record = %{
+  slug: "my-item",
+  data: %{"es-ES" => %{"_slug" => "mi-articulo"}}
+}
+
+EntityData.public_path(entity, record, locale: "es-ES")
+# => "/es/products/mi-articulo"
+```
+
+### Batch usage
+
+For rendering a listing of records, pre-build the routes cache once:
+
+```elixir
+cache = PhoenixKitEntities.UrlResolver.build_routes_cache()
+
+Enum.map(records, fn r ->
+  EntityData.public_path(entity, r, locale: locale, routes_cache: cache)
+end)
+```
+
+---
+
+**Last Updated**: 2026-04-24

--- a/lib/phoenix_kit_entities.ex
+++ b/lib/phoenix_kit_entities.ex
@@ -284,22 +284,42 @@ defmodule PhoenixKitEntities do
   defp notify_entity_event({:ok, %__MODULE__{} = entity}, :created) do
     Events.broadcast_entity_created(entity.uuid)
     maybe_mirror_entity(entity)
+    log_entity_activity(entity, "entity.created")
     {:ok, entity}
   end
 
   defp notify_entity_event({:ok, %__MODULE__{} = entity}, :updated) do
     Events.broadcast_entity_updated(entity.uuid)
     maybe_mirror_entity(entity)
+    log_entity_activity(entity, "entity.updated")
     {:ok, entity}
   end
 
   defp notify_entity_event({:ok, %__MODULE__{} = entity}, :deleted) do
     Events.broadcast_entity_deleted(entity.uuid)
     maybe_delete_mirrored_entity(entity)
+    log_entity_activity(entity, "entity.deleted")
     {:ok, entity}
   end
 
   defp notify_entity_event(result, _event), do: result
+
+  # Records an entity-lifecycle activity entry. Non-crashing — see
+  # `PhoenixKitEntities.ActivityLog` for the guard semantics.
+  defp log_entity_activity(%__MODULE__{} = entity, action) do
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: action,
+      mode: "manual",
+      actor_uuid: entity.created_by_uuid,
+      resource_type: "entity",
+      resource_uuid: entity.uuid,
+      metadata: %{
+        "name" => entity.name,
+        "display_name" => entity.display_name,
+        "status" => entity.status
+      }
+    })
+  end
 
   # Mirror export helpers for auto-sync (per-entity settings)
   defp maybe_mirror_entity(entity) do
@@ -795,11 +815,34 @@ defmodule PhoenixKitEntities do
     :ok
   end
 
-  @doc "Dynamic children function for Entities sidebar tabs."
+  @doc """
+  Dynamic children function for Entities sidebar tabs.
+
+  Supports both arities:
+  - `entities_children(scope, locale)` — preferred when phoenix_kit core
+    (>= pending `dynamic_children/2` release) passes the current locale
+    explicitly to the sidebar callback.
+  - `entities_children(scope)` — fallback that reads the locale from
+    `Gettext.get_locale/1`. Older core releases dispatch this form.
+  """
+  def entities_children(_scope, locale) when is_binary(locale) or is_nil(locale) do
+    cached_entity_summaries(locale || Gettext.get_locale(PhoenixKitWeb.Gettext))
+    |> build_entity_tabs()
+  rescue
+    _ -> []
+  end
+
   def entities_children(_scope) do
     locale = Gettext.get_locale(PhoenixKitWeb.Gettext)
 
     cached_entity_summaries(locale)
+    |> build_entity_tabs()
+  rescue
+    _ -> []
+  end
+
+  defp build_entity_tabs(summaries) do
+    summaries
     |> Enum.with_index()
     |> Enum.map(fn {entity, idx} ->
       %Tab{
@@ -817,8 +860,6 @@ defmodule PhoenixKitEntities do
         parent: :admin_entities
       }
     end)
-  rescue
-    _ -> []
   end
 
   defp cached_entity_summaries(locale) do

--- a/lib/phoenix_kit_entities.ex
+++ b/lib/phoenix_kit_entities.ex
@@ -356,9 +356,10 @@ defmodule PhoenixKitEntities do
   Returns a lightweight list of published entity summaries for sidebar display.
 
   Selects only sidebar-relevant fields without preloading associations.
+  Supports `:lang` option for translation resolution.
   """
-  @spec list_entity_summaries() :: [map()]
-  def list_entity_summaries do
+  @spec list_entity_summaries(keyword()) :: [map()]
+  def list_entity_summaries(opts \\ []) do
     from(e in __MODULE__,
       where: e.status == "published",
       order_by: [desc: e.date_created],
@@ -366,10 +367,18 @@ defmodule PhoenixKitEntities do
         name: e.name,
         display_name: e.display_name,
         display_name_plural: e.display_name_plural,
-        icon: e.icon
+        description: e.description,
+        icon: e.icon,
+        settings: e.settings
       }
     )
     |> repo().all()
+    |> Enum.map(fn summary ->
+      # Convert map to struct for resolve_language, then back to map
+      struct(__MODULE__, summary)
+      |> maybe_resolve_lang(opts)
+      |> Map.take([:name, :display_name, :display_name_plural, :description, :icon, :settings])
+    end)
   end
 
   @doc """
@@ -763,7 +772,9 @@ defmodule PhoenixKitEntities do
     alias PhoenixKit.Dashboard.Registry, as: DashboardRegistry
 
     if DashboardRegistry.initialized?() do
-      :ets.delete(DashboardRegistry.ets_table(), @entities_cache_key)
+      # Delete all entries for this cache key across all locales
+      # Pattern matches: {{:entities_children_cache, _}, _, _}
+      :ets.match_delete(DashboardRegistry.ets_table(), {{@entities_cache_key, :_}, :_, :_})
     end
 
     :ok
@@ -771,7 +782,9 @@ defmodule PhoenixKitEntities do
 
   @doc "Dynamic children function for Entities sidebar tabs."
   def entities_children(_scope) do
-    cached_entity_summaries()
+    locale = Gettext.get_locale(PhoenixKitWeb.Gettext)
+
+    cached_entity_summaries(locale)
     |> Enum.with_index()
     |> Enum.map(fn {entity, idx} ->
       %Tab{
@@ -793,36 +806,38 @@ defmodule PhoenixKitEntities do
     _ -> []
   end
 
-  defp cached_entity_summaries do
+  defp cached_entity_summaries(locale) do
     alias PhoenixKit.Dashboard.Registry, as: DashboardRegistry
 
     if DashboardRegistry.initialized?() do
-      lookup_cached_entities(DashboardRegistry)
+      lookup_cached_entities(DashboardRegistry, locale)
     else
-      list_entity_summaries()
+      list_entity_summaries(lang: locale)
     end
   end
 
-  defp lookup_cached_entities(registry) do
-    case :ets.lookup(registry.ets_table(), @entities_cache_key) do
-      [{@entities_cache_key, entities, timestamp}] when is_integer(timestamp) ->
+  defp lookup_cached_entities(registry, locale) do
+    cache_key = {@entities_cache_key, locale}
+
+    case :ets.lookup(registry.ets_table(), cache_key) do
+      [{^cache_key, entities, timestamp}] when is_integer(timestamp) ->
         if System.monotonic_time(:millisecond) - timestamp < @entities_cache_ttl_ms,
           do: entities,
-          else: fetch_and_cache_entities()
+          else: fetch_and_cache_entities(locale)
 
       _ ->
-        fetch_and_cache_entities()
+        fetch_and_cache_entities(locale)
     end
   end
 
-  defp fetch_and_cache_entities do
+  defp fetch_and_cache_entities(locale) do
     alias PhoenixKit.Dashboard.Registry, as: DashboardRegistry
-    entities = list_entity_summaries()
+    entities = list_entity_summaries(lang: locale)
 
     if DashboardRegistry.initialized?() do
       :ets.insert(
         DashboardRegistry.ets_table(),
-        {@entities_cache_key, entities, System.monotonic_time(:millisecond)}
+        {{@entities_cache_key, locale}, entities, System.monotonic_time(:millisecond)}
       )
     end
 
@@ -1257,7 +1272,9 @@ defmodule PhoenixKitEntities do
       iex> resolve_language(entity, "en-US")  # primary language
       %PhoenixKitEntities{display_name: "Products", ...}
   """
-  @spec resolve_language(t(), String.t()) :: t()
+  @spec resolve_language(t(), String.t() | nil) :: t()
+  def resolve_language(entity, nil), do: entity
+
   def resolve_language(%__MODULE__{} = entity, lang_code) when is_binary(lang_code) do
     translation = get_entity_translation(entity, lang_code)
 
@@ -1282,13 +1299,15 @@ defmodule PhoenixKitEntities do
       iex> resolve_languages(entities, "es-ES")
       [%PhoenixKitEntities{display_name: "Productos"}, ...]
   """
-  @spec resolve_languages([t()], String.t()) :: [t()]
+  @spec resolve_languages([t()], String.t() | nil) :: [t()]
+  def resolve_languages(entities, nil), do: entities
+
   def resolve_languages(entities, lang_code) when is_list(entities) and is_binary(lang_code) do
     Enum.map(entities, &resolve_language(&1, lang_code))
   end
 
-  # Applies :lang option to a single entity if present in opts
-  defp maybe_resolve_lang(entity, opts) when is_list(opts) do
+  @doc false
+  def maybe_resolve_lang(entity, opts) when is_list(opts) do
     case Keyword.get(opts, :lang) do
       nil -> entity
       lang -> resolve_language(entity, lang)

--- a/lib/phoenix_kit_entities.ex
+++ b/lib/phoenix_kit_entities.ex
@@ -360,26 +360,41 @@ defmodule PhoenixKitEntities do
   """
   @spec list_entity_summaries(keyword()) :: [map()]
   def list_entity_summaries(opts \\ []) do
-    from(e in __MODULE__,
-      where: e.status == "published",
-      order_by: [desc: e.date_created],
-      select: %{
-        name: e.name,
-        display_name: e.display_name,
-        display_name_plural: e.display_name_plural,
-        description: e.description,
-        icon: e.icon,
-        settings: e.settings
-      }
-    )
-    |> repo().all()
-    |> Enum.map(fn summary ->
-      # Convert map to struct for resolve_language, then back to map
-      struct(__MODULE__, summary)
-      |> maybe_resolve_lang(opts)
-      |> Map.take([:name, :display_name, :display_name_plural, :description, :icon, :settings])
-    end)
+    summaries =
+      from(e in __MODULE__,
+        where: e.status == "published",
+        order_by: [desc: e.date_created],
+        select: %{
+          name: e.name,
+          display_name: e.display_name,
+          display_name_plural: e.display_name_plural,
+          description: e.description,
+          icon: e.icon,
+          settings: e.settings
+        }
+      )
+      |> repo().all()
+
+    case Keyword.get(opts, :lang) do
+      nil -> summaries
+      lang -> Enum.map(summaries, &resolve_summary_language(&1, lang))
+    end
   end
+
+  # Resolves display_name / display_name_plural / description on a summary map,
+  # matching the behaviour of resolve_language/2 without a struct round-trip.
+  defp resolve_summary_language(summary, lang_code) do
+    translations = get_in(summary, [:settings, "translations", lang_code]) || %{}
+
+    summary
+    |> maybe_put_translation(:display_name, translations["display_name"])
+    |> maybe_put_translation(:display_name_plural, translations["display_name_plural"])
+    |> maybe_put_translation(:description, translations["description"])
+  end
+
+  defp maybe_put_translation(summary, _field, nil), do: summary
+  defp maybe_put_translation(summary, _field, ""), do: summary
+  defp maybe_put_translation(summary, field, value), do: Map.put(summary, field, value)
 
   @doc """
   Gets a single entity by integer ID or UUID.

--- a/lib/phoenix_kit_entities/OVERVIEW.md
+++ b/lib/phoenix_kit_entities/OVERVIEW.md
@@ -12,6 +12,7 @@ PhoenixKit's Entities layer is a dynamic content type engine. It lets administra
 - **Admin UI** – LiveView dashboards for managing blueprints, browsing/creating data, filtering, and adjusting module settings.
 - **Settings + security** – Feature toggle and max entities per user are enforced; additional settings (relation/file flags, auto slugging, etc.) are persisted in `phoenix_kit_settings` but reserved for future use. All surfaces are gated behind the admin scope.
 - **Statistics** – Counts and summaries for dashboards and monitoring.
+- **URL Resolution Engine** – Robust path resolution logic that introspects the router and entity settings to generate localized public URLs for records.
 - **Public Form Builder** – Create embeddable forms for public-facing pages with security features (honeypot, time-based validation, rate limiting), configurable actions, and submission statistics.
 
 ---
@@ -22,6 +23,7 @@ PhoenixKit's Entities layer is a dynamic content type engine. It lets administra
 lib/modules/entities/
 ├── entities.ex          # Entity schema + business logic
 ├── entity_data.ex       # Data record schema + CRUD helpers
+├── url_resolver.ex      # URL resolution engine for public paths
 ├── field_types.ex       # Registry of supported field types
 ├── form_builder.ex      # Dynamic form rendering + validation helpers
 ├── multilang.ex         # Multi-language data transformation helpers
@@ -122,11 +124,19 @@ Field validation pipeline ensures every entry in `fields_definition` has `type/k
 Manages actual records:
 - Schema + changeset verifying required fields, slug format, status, and cross-checking submitted JSON against the entity definition.
 - CRUD and query helpers (`list_all/1`, `list_by_entity/2`, `get!/2`, `get/2`, `search_by_title/3`, `create/1`, `update/2`, `delete/1`, `change/2`). All query functions accept an optional `lang:` keyword option for language-aware results.
+- Public URL helpers (`public_path/3`, `public_url/3`) for generating localized front-end links.
 - Ordering helpers (`update_position/2`, `move_to_position/2`, `reorder/2`, `bulk_update_positions/1`, `next_position/1`). Queries automatically respect the parent entity's sort mode.
 - Language resolution (`resolve_language/2`, `resolve_languages/2`) for applying translations to data record structs.
 - Field-level validation ensures required fields are present, numbers are numeric, booleans are booleans, options exist, etc.
 
 Note: `create/1` auto-fills `created_by_uuid` with the first admin user if not provided. It also auto-populates `position` with the next sequential value for the entity.
+
+### `PhoenixKitEntities.UrlResolver`
+Shared engine for resolving public URLs:
+- Introspects the application router for entity-specific or catchall routes.
+- Respects `sitemap_url_pattern` and `sitemap_index_path` settings from entity blueprints.
+- Handles locale prefixing for multi-language systems.
+- Used by both the `SitemapSource` and `EntityData.public_url/3`.
 
 ### `PhoenixKitEntities.FieldTypes`
 Registry of supported field types with metadata:

--- a/lib/phoenix_kit_entities/activity_log.ex
+++ b/lib/phoenix_kit_entities/activity_log.ex
@@ -1,0 +1,58 @@
+defmodule PhoenixKitEntities.ActivityLog do
+  @moduledoc false
+  # Shared activity-logging helper for entity + entity_data mutations.
+  # Wraps `PhoenixKit.Activity.log/1` with the "entities" module key.
+  #
+  # The core Activity context is optional — parent apps that don't install it
+  # will simply skip logging. We guard with `Code.ensure_loaded?/1` and a
+  # try/rescue so a logging failure never propagates back to the caller.
+
+  require Logger
+
+  @module_key "entities"
+
+  @doc """
+  Logs an activity entry with `module: "entities"` injected.
+
+  Never raises — swallows any error from the Activity context with a Logger
+  warning so the caller's primary mutation isn't affected.
+  """
+  @spec log(map()) :: :ok
+  def log(attrs) when is_map(attrs) do
+    if Code.ensure_loaded?(PhoenixKit.Activity) do
+      try do
+        PhoenixKit.Activity.log(Map.put(attrs, :module, @module_key))
+      rescue
+        error ->
+          Logger.warning(
+            "PhoenixKitEntities activity log failed: " <>
+              "#{Exception.message(error)} — attrs=" <>
+              inspect(Map.take(attrs, [:action, :resource_type, :resource_uuid]))
+          )
+      end
+    end
+
+    :ok
+  end
+
+  @doc """
+  Runs `op_fun` and, on `{:ok, record}`, logs an activity entry built from
+  `attrs_fun.(record)`. Collapses the common `case Repo.insert(...) do ...`
+  shape used in each mutation path.
+
+  `op_fun` returns `{:ok, term} | {:error, term}`; `attrs_fun` only runs on
+  success.
+  """
+  @spec with_log((-> {:ok, term()} | {:error, term()}), (term() -> map())) ::
+          {:ok, term()} | {:error, term()}
+  def with_log(op_fun, attrs_fun) when is_function(op_fun, 0) and is_function(attrs_fun, 1) do
+    case op_fun.() do
+      {:ok, record} = ok ->
+        log(attrs_fun.(record))
+        ok
+
+      {:error, _} = err ->
+        err
+    end
+  end
+end

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -393,22 +393,43 @@ defmodule PhoenixKitEntities.EntityData do
   defp notify_data_event({:ok, %__MODULE__{} = entity_data}, :created) do
     Events.broadcast_data_created(entity_data.entity_uuid, entity_data.uuid)
     maybe_mirror_data(entity_data)
+    log_data_activity(entity_data, "entity_data.created")
     {:ok, entity_data}
   end
 
   defp notify_data_event({:ok, %__MODULE__{} = entity_data}, :updated) do
     Events.broadcast_data_updated(entity_data.entity_uuid, entity_data.uuid)
     maybe_mirror_data(entity_data)
+    log_data_activity(entity_data, "entity_data.updated")
     {:ok, entity_data}
   end
 
   defp notify_data_event({:ok, %__MODULE__{} = entity_data}, :deleted) do
     Events.broadcast_data_deleted(entity_data.entity_uuid, entity_data.uuid)
     maybe_delete_mirrored_data(entity_data)
+    log_data_activity(entity_data, "entity_data.deleted")
     {:ok, entity_data}
   end
 
   defp notify_data_event(result, _event), do: result
+
+  # Records a data-record-lifecycle activity entry. Non-crashing — see
+  # `PhoenixKitEntities.ActivityLog` for the guard semantics.
+  defp log_data_activity(%__MODULE__{} = entity_data, action) do
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: action,
+      mode: "manual",
+      actor_uuid: entity_data.created_by_uuid,
+      resource_type: "entity_data",
+      resource_uuid: entity_data.uuid,
+      metadata: %{
+        "entity_uuid" => entity_data.entity_uuid,
+        "title" => entity_data.title,
+        "slug" => entity_data.slug,
+        "status" => entity_data.status
+      }
+    })
+  end
 
   # Broadcast a reorder event for an entity so live views refresh.
   defp notify_reorder_event(entity_uuid) when is_binary(entity_uuid) do
@@ -984,6 +1005,12 @@ defmodule PhoenixKitEntities.EntityData do
   - Primary language → no prefix (default locale served at unprefixed URL)
   - Other locales → prefixed with the base code (`/es/...`, `/ru/...`)
 
+  Slug resolution:
+  - When `:locale` is given and the record has a secondary-language slug
+    override stored as `data[locale]["_slug"]`, that override is substituted
+    for `:slug` in the pattern. Otherwise the primary `record.slug` is used
+    (falling back to the UUID when slug is nil).
+
   ## Options
 
     * `:locale` — locale code (dialect like `"es-ES"` or base `"es"`). Omit to skip prefixing.
@@ -1006,10 +1033,34 @@ defmodule PhoenixKitEntities.EntityData do
     cache = Keyword.get(opts, :routes_cache) || UrlResolver.build_routes_cache()
 
     pattern = UrlResolver.get_url_pattern_cached(entity, cache) || "/#{entity.name}/:slug"
-    path = UrlResolver.build_path(pattern, record)
+    localized_record = maybe_apply_translated_slug(record, locale)
+    path = UrlResolver.build_path(pattern, localized_record)
 
     UrlResolver.add_public_locale_prefix(path, locale)
   end
+
+  # If the record carries a secondary-language `_slug` override for the
+  # requested locale, swap it onto the record before placeholder substitution.
+  # Keeps the URL stable in the primary language and lets `/es/products/mi-item`
+  # use `mi-item` instead of the English slug.
+  defp maybe_apply_translated_slug(record, nil), do: record
+  defp maybe_apply_translated_slug(record, ""), do: record
+
+  defp maybe_apply_translated_slug(record, locale) when is_binary(locale) do
+    case translated_slug(record, locale) do
+      nil -> record
+      translated -> Map.put(record, :slug, translated)
+    end
+  end
+
+  defp translated_slug(%{data: data}, locale) when is_map(data) do
+    case get_in(data, [locale, "_slug"]) do
+      slug when is_binary(slug) and slug != "" -> slug
+      _ -> nil
+    end
+  end
+
+  defp translated_slug(_record, _locale), do: nil
 
   @doc """
   Returns a full public URL for a record by prepending a base URL to `public_path/3`.

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -81,6 +81,7 @@ defmodule PhoenixKitEntities.EntityData do
   alias PhoenixKitEntities, as: Entities
   alias PhoenixKitEntities.Events
   alias PhoenixKitEntities.Mirror.Exporter
+  alias PhoenixKitEntities.UrlResolver
   @type t :: %__MODULE__{}
 
   @primary_key {:uuid, UUIDv7, autogenerate: true}
@@ -965,6 +966,72 @@ defmodule PhoenixKitEntities.EntityData do
     )
     |> repo().all()
     |> maybe_resolve_langs(opts)
+  end
+
+  @doc """
+  Returns a public path for a record, respecting locale and the configured URL pattern.
+
+  URL pattern resolution chain (shared with `PhoenixKitEntities.SitemapSource`):
+  1. `entity.settings["sitemap_url_pattern"]`
+  2. Router introspection (via `PhoenixKit.Modules.Sitemap.RouteResolver`)
+  3. Per-entity setting `sitemap_entity_<name>_pattern`
+  4. Global pattern setting `sitemap_entities_pattern`
+  5. Fallback `/<entity_name>/:slug`
+
+  Locale prefix policy (matches `PhoenixKit.Utils.Routes.path/2`):
+  - `:locale` omitted or `nil` → no prefix
+  - Single-language mode → no prefix
+  - Primary language → no prefix (default locale served at unprefixed URL)
+  - Other locales → prefixed with the base code (`/es/...`, `/ru/...`)
+
+  ## Options
+
+    * `:locale` — locale code (dialect like `"es-ES"` or base `"es"`). Omit to skip prefixing.
+    * `:routes_cache` — pre-built cache from `UrlResolver.build_routes_cache/0` (for batches).
+
+  ## Examples
+
+      iex> EntityData.public_path(entity, record)
+      "/products/my-item"
+
+      iex> EntityData.public_path(entity, record, locale: "es-ES")
+      "/es/products/my-item"
+
+      iex> EntityData.public_path(entity, record, locale: "en-US")  # primary language
+      "/products/my-item"
+  """
+  @spec public_path(map(), map(), keyword()) :: String.t()
+  def public_path(entity, record, opts \\ []) do
+    locale = Keyword.get(opts, :locale)
+    cache = Keyword.get(opts, :routes_cache) || UrlResolver.build_routes_cache()
+
+    pattern = UrlResolver.get_url_pattern_cached(entity, cache) || "/#{entity.name}/:slug"
+    path = UrlResolver.build_path(pattern, record)
+
+    UrlResolver.add_public_locale_prefix(path, locale)
+  end
+
+  @doc """
+  Returns a full public URL for a record by prepending a base URL to `public_path/3`.
+
+  ## Options
+
+    * `:base_url` — explicit base (e.g. `"https://site.com"`). Falls back to the
+      `site_url` setting, then an empty string.
+    * `:locale` — forwarded to `public_path/3`.
+    * `:routes_cache` — forwarded to `public_path/3`.
+
+  ## Examples
+
+      iex> EntityData.public_url(entity, record, base_url: "https://shop.example.com")
+      "https://shop.example.com/products/my-item"
+  """
+  @spec public_url(map(), map(), keyword()) :: String.t()
+  def public_url(entity, record, opts \\ []) do
+    path = public_path(entity, record, opts)
+    base_url = Keyword.get(opts, :base_url)
+
+    UrlResolver.build_url(path, base_url)
   end
 
   @doc """

--- a/lib/phoenix_kit_entities/sitemap_source.ex
+++ b/lib/phoenix_kit_entities/sitemap_source.ex
@@ -86,12 +86,11 @@ defmodule PhoenixKitEntities.SitemapSource do
 
   require Logger
 
-  alias PhoenixKit.Modules.Languages
   alias PhoenixKit.Modules.Sitemap.RouteResolver
   alias PhoenixKit.Modules.Sitemap.UrlEntry
   alias PhoenixKit.Settings
-  alias PhoenixKitEntities, as: Entities
   alias PhoenixKitEntities.EntityData
+  alias PhoenixKitEntities.UrlResolver
 
   @impl true
   def source_name, do: :entities
@@ -111,10 +110,10 @@ defmodule PhoenixKitEntities.SitemapSource do
       base_url = Keyword.get(opts, :base_url)
       language = Keyword.get(opts, :language)
       include_index = Settings.get_boolean_setting("sitemap_entities_include_index", true)
-      routes_cache = build_routes_cache()
+      routes_cache = UrlResolver.build_routes_cache()
 
       sub_maps =
-        Entities.list_active_entities()
+        PhoenixKitEntities.list_active_entities()
         |> Enum.filter(&entity_has_public_route?(&1, routes_cache))
         |> Enum.map(fn entity ->
           entries =
@@ -141,7 +140,7 @@ defmodule PhoenixKitEntities.SitemapSource do
 
   @impl true
   def enabled? do
-    Entities.enabled?()
+    PhoenixKitEntities.enabled?()
   rescue
     _ -> false
   end
@@ -170,7 +169,7 @@ defmodule PhoenixKitEntities.SitemapSource do
     include_index = Settings.get_boolean_setting("sitemap_entities_include_index", true)
 
     # Optimization: Get all routes ONCE and build lookup map
-    routes_cache = build_routes_cache()
+    routes_cache = UrlResolver.build_routes_cache()
 
     # Early exit if no public entity routes exist
     if map_size(routes_cache.entity_patterns) == 0 and
@@ -178,111 +177,11 @@ defmodule PhoenixKitEntities.SitemapSource do
       Logger.debug("Sitemap: No public entity routes found, skipping entities source")
       []
     else
-      Entities.list_active_entities()
+      PhoenixKitEntities.list_active_entities()
       |> Enum.filter(&entity_has_public_route?(&1, routes_cache))
       |> Enum.flat_map(
         &collect_entity_entries(&1, base_url, include_index, language, is_default, routes_cache)
       )
-    end
-  end
-
-  # Build a cache of all routes for efficient lookups
-  defp build_routes_cache do
-    routes = RouteResolver.get_routes()
-
-    # Pre-filter GET routes with :slug or :id params (content routes)
-    content_routes =
-      Enum.filter(routes, fn route ->
-        route.verb == :get and
-          (String.contains?(route.path, ":slug") or String.contains?(route.path, ":id"))
-      end)
-
-    # Pre-filter GET routes without params (index routes)
-    index_routes =
-      Enum.filter(routes, fn route ->
-        route.verb == :get and
-          not String.contains?(route.path, ":") and
-          not String.contains?(route.path, "*")
-      end)
-
-    # Build entity name -> pattern map for quick lookups
-    entity_patterns = build_entity_pattern_map(content_routes)
-    entity_index_paths = build_entity_index_map(index_routes)
-
-    %{
-      all_routes: routes,
-      content_routes: content_routes,
-      index_routes: index_routes,
-      entity_patterns: entity_patterns,
-      entity_index_paths: entity_index_paths
-    }
-  end
-
-  # Build map of entity_name -> url_pattern from routes
-  # Also detects catchall routes like /:entity_name/:slug
-  defp build_entity_pattern_map(content_routes) do
-    # Check for catchall route first
-    catchall_route = find_catchall_content_route(content_routes)
-
-    content_routes
-    |> Enum.reduce(%{catchall: catchall_route}, fn route, acc ->
-      path_lower = String.downcase(route.path)
-
-      # Extract entity name from path like /products/:slug or /product/:id
-      case extract_entity_from_path(path_lower) do
-        nil -> acc
-        entity_name -> Map.put_new(acc, entity_name, route.path)
-      end
-    end)
-  end
-
-  # Build map of entity_name -> index_path from routes
-  # Also detects catchall routes like /:entity_name
-  defp build_entity_index_map(index_routes) do
-    # Check for catchall index route first
-    catchall_route = find_catchall_index_route(index_routes)
-
-    index_routes
-    |> Enum.reduce(%{catchall: catchall_route}, fn route, acc ->
-      path_lower = String.downcase(route.path)
-
-      # Extract entity name from path like /products or /product
-      case extract_entity_from_index_path(path_lower) do
-        nil -> acc
-        entity_name -> Map.put_new(acc, entity_name, route.path)
-      end
-    end)
-  end
-
-  # Find catchall content route like /:entity_name/:slug
-  defp find_catchall_content_route(routes) do
-    Enum.find(routes, fn route ->
-      # Match patterns like /:entity_name/:slug, /:name/:slug, /:type/:id
-      Regex.match?(~r{^/:[a-z_]+/:[a-z_]+$}, route.path)
-    end)
-  end
-
-  # Find catchall index route like /:entity_name
-  defp find_catchall_index_route(routes) do
-    Enum.find(routes, fn route ->
-      # Match patterns like /:entity_name, /:name (single param at root)
-      Regex.match?(~r{^/:[a-z_]+$}, route.path)
-    end)
-  end
-
-  # Extract entity name from content path like /products/:slug -> "product"
-  defp extract_entity_from_path(path) do
-    case Regex.run(~r{^/([a-z_]+)s?/:[a-z_]+$}, path) do
-      [_, name] -> String.trim_trailing(name, "s")
-      _ -> nil
-    end
-  end
-
-  # Extract entity name from index path like /products -> "product"
-  defp extract_entity_from_index_path(path) do
-    case Regex.run(~r{^/([a-z_]+)s?$}, path) do
-      [_, name] -> String.trim_trailing(name, "s")
-      _ -> nil
     end
   end
 
@@ -342,7 +241,7 @@ defmodule PhoenixKitEntities.SitemapSource do
   end
 
   defp do_collect_entity_records(entity, base_url, language, is_default, routes_cache) do
-    url_pattern = get_url_pattern_cached(entity, routes_cache)
+    url_pattern = UrlResolver.get_url_pattern_cached(entity, routes_cache)
     effective_pattern = url_pattern || get_fallback_pattern(entity)
 
     if effective_pattern do
@@ -388,13 +287,13 @@ defmodule PhoenixKitEntities.SitemapSource do
 
   # Collect index page entry for entity (e.g., /page, /products) - cached version
   defp collect_entity_index(entity, base_url, language, is_default, routes_cache) do
-    index_path = get_index_path_cached(entity, routes_cache)
+    index_path = UrlResolver.get_index_path_cached(entity, routes_cache)
 
     if index_path do
       # Canonical path without language prefix (for hreflang grouping)
       canonical_path = index_path
-      path = build_path_with_language(index_path, language, is_default)
-      url = build_url(path, base_url)
+      path = UrlResolver.build_path_with_language(index_path, language, is_default)
+      url = UrlResolver.build_url(path, base_url)
 
       UrlEntry.new(%{
         loc: url,
@@ -413,100 +312,6 @@ defmodule PhoenixKitEntities.SitemapSource do
     error ->
       Logger.warning("Failed to collect index for entity #{entity.name}: #{inspect(error)}")
       nil
-  end
-
-  # Get index path using cached routes (no RouteResolver calls)
-  # Priority: entity settings -> cached lookup -> catchall -> per-entity settings -> fallback
-  defp get_index_path_cached(entity, routes_cache) do
-    get_index_from_entity_settings(entity) ||
-      get_index_from_cache(entity, routes_cache) ||
-      get_index_from_catchall(entity, routes_cache) ||
-      get_index_from_settings(entity) ||
-      get_fallback_index_path(entity)
-  end
-
-  defp get_index_from_entity_settings(entity) do
-    case entity.settings do
-      %{"sitemap_index_path" => path} when is_binary(path) and path != "" -> path
-      _ -> nil
-    end
-  end
-
-  defp get_index_from_cache(entity, routes_cache) do
-    entity_lower = String.downcase(entity.name)
-
-    Map.get(routes_cache.entity_index_paths, entity_lower) ||
-      Map.get(routes_cache.entity_index_paths, entity.name)
-  end
-
-  defp get_index_from_catchall(entity, routes_cache) do
-    case routes_cache.entity_index_paths[:catchall] do
-      %{path: _} -> "/#{entity.name}"
-      _ -> nil
-    end
-  end
-
-  defp get_index_from_settings(entity) do
-    Settings.get_setting("sitemap_entity_#{entity.name}_index_path")
-  end
-
-  # Fallback index path using entity name - disabled by default
-  defp get_fallback_index_path(entity) do
-    if Settings.get_boolean_setting("sitemap_entities_auto_pattern", false) do
-      "/#{entity.name}"
-    else
-      nil
-    end
-  end
-
-  # Get URL pattern using cached routes (no RouteResolver calls)
-  # Fallback chain: entity.settings -> cached routes -> per-entity settings -> global pattern
-  defp get_url_pattern_cached(entity, routes_cache) do
-    get_pattern_from_entity_settings(entity) ||
-      get_pattern_from_cache(entity, routes_cache) ||
-      get_pattern_from_settings(entity)
-  end
-
-  defp get_pattern_from_entity_settings(entity) do
-    case entity.settings do
-      %{"sitemap_url_pattern" => pattern} when is_binary(pattern) and pattern != "" -> pattern
-      _ -> nil
-    end
-  end
-
-  defp get_pattern_from_cache(entity, routes_cache) do
-    entity_lower = String.downcase(entity.name)
-
-    # First try explicit route for this entity
-    explicit_pattern =
-      Map.get(routes_cache.entity_patterns, entity_lower) ||
-        Map.get(routes_cache.entity_patterns, entity.name)
-
-    if explicit_pattern do
-      explicit_pattern
-    else
-      # Fall back to catchall route, replacing param with entity name
-      case routes_cache.entity_patterns[:catchall] do
-        nil -> nil
-        %{path: path} -> String.replace(path, ~r{^/:[a-z_]+/}, "/#{entity.name}/")
-      end
-    end
-  end
-
-  defp get_pattern_from_settings(entity) do
-    per_entity_key = "sitemap_entity_#{entity.name}_pattern"
-
-    case Settings.get_setting(per_entity_key) do
-      nil -> get_global_pattern(entity)
-      pattern -> pattern
-    end
-  end
-
-  defp get_global_pattern(entity) do
-    case Settings.get_setting("sitemap_entities_pattern") do
-      nil -> nil
-      global_pattern -> String.replace(global_pattern, ":entity_name", entity.name)
-    end
   end
 
   # Check if entity requires auth using cached routes
@@ -549,9 +354,9 @@ defmodule PhoenixKitEntities.SitemapSource do
 
   defp build_entry(record, entity, url_pattern, base_url, language, is_default) do
     # Canonical path without language prefix (for hreflang grouping)
-    canonical_path = build_path(url_pattern, record)
-    path = build_path_with_language(canonical_path, language, is_default)
-    url = build_url(path, base_url)
+    canonical_path = UrlResolver.build_path(url_pattern, record)
+    path = UrlResolver.build_path_with_language(canonical_path, language, is_default)
+    url = UrlResolver.build_url(path, base_url)
 
     UrlEntry.new(%{
       loc: url,
@@ -563,45 +368,5 @@ defmodule PhoenixKitEntities.SitemapSource do
       source: :entities,
       canonical_path: canonical_path
     })
-  end
-
-  defp build_path(pattern, record) do
-    pattern
-    |> String.replace(":slug", record.slug || to_string(record.uuid))
-    |> String.replace(":id", to_string(record.uuid))
-  end
-
-  # Add language prefix to path when in multi-language mode
-  # Single language: no prefix for anyone
-  # Multiple languages: ALL languages get prefix (including default)
-  defp build_path_with_language(path, language, _is_default) do
-    if language && !single_language_mode?() do
-      "/#{Languages.DialectMapper.extract_base(language)}#{path}"
-    else
-      path
-    end
-  end
-
-  # Check if we're in single language mode (no locale prefix needed)
-  # Returns true when languages module is off OR only one language is enabled
-  # Mirrors PublishingHTML.single_language_mode?/0 logic
-  defp single_language_mode? do
-    not Languages.enabled?() or length(Languages.get_enabled_languages()) <= 1
-  rescue
-    _ -> true
-  end
-
-  # Build URL for public entity pages (no PhoenixKit prefix)
-  defp build_url(path, nil) do
-    # Fallback to site_url from settings
-    base = PhoenixKit.Settings.get_setting("site_url", "")
-    normalized_base = String.trim_trailing(base, "/")
-    "#{normalized_base}#{path}"
-  end
-
-  defp build_url(path, base_url) when is_binary(base_url) do
-    # Entity pages are public - no PhoenixKit prefix needed
-    normalized_base = String.trim_trailing(base_url, "/")
-    "#{normalized_base}#{path}"
   end
 end

--- a/lib/phoenix_kit_entities/url_resolver.ex
+++ b/lib/phoenix_kit_entities/url_resolver.ex
@@ -1,0 +1,321 @@
+defmodule PhoenixKitEntities.UrlResolver do
+  @moduledoc """
+  Logic for resolving entity and record URLs based on router introspection,
+  entity settings, and global configuration.
+
+  Extracted from SitemapSource to provide a shared API for public URL generation.
+  """
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Modules.Sitemap.RouteResolver
+  alias PhoenixKit.Settings
+  alias PhoenixKit.Utils.Multilang
+
+  @doc """
+  Builds a cache of all routes for efficient lookups.
+  """
+  def build_routes_cache do
+    routes = RouteResolver.get_routes()
+
+    # Pre-filter GET routes with :slug or :id params (content routes)
+    content_routes =
+      Enum.filter(routes, fn route ->
+        route.verb == :get and
+          (String.contains?(route.path, ":slug") or String.contains?(route.path, ":id"))
+      end)
+
+    # Pre-filter GET routes without params (index routes)
+    index_routes =
+      Enum.filter(routes, fn route ->
+        route.verb == :get and
+          not String.contains?(route.path, ":") and
+          not String.contains?(route.path, "*")
+      end)
+
+    # Build entity name -> pattern map for quick lookups
+    entity_patterns = build_entity_pattern_map(content_routes)
+    entity_index_paths = build_entity_index_map(index_routes)
+
+    %{
+      all_routes: routes,
+      content_routes: content_routes,
+      index_routes: index_routes,
+      entity_patterns: entity_patterns,
+      entity_index_paths: entity_index_paths
+    }
+  end
+
+  # Build map of entity_name -> url_pattern from routes
+  # Also detects catchall routes like /:entity_name/:slug
+  defp build_entity_pattern_map(content_routes) do
+    # Check for catchall route first
+    catchall_route = find_catchall_content_route(content_routes)
+
+    content_routes
+    |> Enum.reduce(%{catchall: catchall_route}, fn route, acc ->
+      path_lower = String.downcase(route.path)
+
+      # Extract entity name from path like /products/:slug or /product/:id
+      case extract_entity_from_path(path_lower) do
+        nil -> acc
+        entity_name -> Map.put_new(acc, entity_name, route.path)
+      end
+    end)
+  end
+
+  # Build map of entity_name -> index_path from routes
+  # Also detects catchall routes like /:entity_name
+  defp build_entity_index_map(index_routes) do
+    # Check for catchall index route first
+    catchall_route = find_catchall_index_route(index_routes)
+
+    index_routes
+    |> Enum.reduce(%{catchall: catchall_route}, fn route, acc ->
+      path_lower = String.downcase(route.path)
+
+      # Extract entity name from path like /products or /product
+      case extract_entity_from_index_path(path_lower) do
+        nil -> acc
+        entity_name -> Map.put_new(acc, entity_name, route.path)
+      end
+    end)
+  end
+
+  # Find catchall content route like /:entity_name/:slug
+  defp find_catchall_content_route(routes) do
+    Enum.find(routes, fn route ->
+      # Match patterns like /:entity_name/:slug, /:name/:slug, /:type/:id
+      Regex.match?(~r{^/:[a-z_]+/:[a-z_]+$}, route.path)
+    end)
+  end
+
+  # Find catchall index route like /:entity_name
+  defp find_catchall_index_route(routes) do
+    Enum.find(routes, fn route ->
+      # Match patterns like /:entity_name, /:name (single param at root)
+      Regex.match?(~r{^/:[a-z_]+$}, route.path)
+    end)
+  end
+
+  # Extract entity name from content path like /products/:slug -> "product"
+  defp extract_entity_from_path(path) do
+    case Regex.run(~r{^/([a-z_]+)s?/:[a-z_]+$}, path) do
+      [_, name] -> String.trim_trailing(name, "s")
+      _ -> nil
+    end
+  end
+
+  # Extract entity name from index path like /products -> "product"
+  defp extract_entity_from_index_path(path) do
+    case Regex.run(~r{^/([a-z_]+)s?$}, path) do
+      [_, name] -> String.trim_trailing(name, "s")
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Gets the URL pattern for an entity using cached routes.
+  """
+  def get_url_pattern_cached(entity, routes_cache) do
+    get_pattern_from_entity_settings(entity) ||
+      get_pattern_from_cache(entity, routes_cache) ||
+      get_pattern_from_settings(entity)
+  end
+
+  defp get_pattern_from_entity_settings(entity) do
+    case entity.settings do
+      %{"sitemap_url_pattern" => pattern} when is_binary(pattern) and pattern != "" -> pattern
+      _ -> nil
+    end
+  end
+
+  defp get_pattern_from_cache(entity, routes_cache) do
+    entity_lower = String.downcase(entity.name)
+
+    # First try explicit route for this entity
+    explicit_pattern =
+      Map.get(routes_cache.entity_patterns, entity_lower) ||
+        Map.get(routes_cache.entity_patterns, entity.name)
+
+    if explicit_pattern do
+      explicit_pattern
+    else
+      # Fall back to catchall route, replacing param with entity name
+      case routes_cache.entity_patterns[:catchall] do
+        nil -> nil
+        %{path: path} -> String.replace(path, ~r{^/:[a-z_]+/}, "/#{entity.name}/")
+      end
+    end
+  end
+
+  defp get_pattern_from_settings(entity) do
+    per_entity_key = "sitemap_entity_#{entity.name}_pattern"
+
+    case safe_get_setting(per_entity_key) do
+      nil -> get_global_pattern(entity)
+      pattern -> pattern
+    end
+  end
+
+  defp get_global_pattern(entity) do
+    case safe_get_setting("sitemap_entities_pattern") do
+      nil -> nil
+      global_pattern -> String.replace(global_pattern, ":entity_name", entity.name)
+    end
+  end
+
+  # Settings lookup may fail if the Settings table isn't available (tests without
+  # a repo, transient DB issues, misinstalled module). In that case we want
+  # URL generation to fall through the chain, not crash the caller.
+  defp safe_get_setting(key) do
+    Settings.get_setting(key)
+  rescue
+    _ -> nil
+  end
+
+  defp safe_get_setting(key, default) do
+    Settings.get_setting(key, default)
+  rescue
+    _ -> default
+  end
+
+  @doc """
+  Gets the index path for an entity using cached routes.
+  """
+  def get_index_path_cached(entity, routes_cache) do
+    get_index_from_entity_settings(entity) ||
+      get_index_from_cache(entity, routes_cache) ||
+      get_index_from_catchall(entity, routes_cache) ||
+      get_index_from_settings(entity) ||
+      get_fallback_index_path(entity)
+  end
+
+  defp get_index_from_entity_settings(entity) do
+    case entity.settings do
+      %{"sitemap_index_path" => path} when is_binary(path) and path != "" -> path
+      _ -> nil
+    end
+  end
+
+  defp get_index_from_cache(entity, routes_cache) do
+    entity_lower = String.downcase(entity.name)
+
+    Map.get(routes_cache.entity_index_paths, entity_lower) ||
+      Map.get(routes_cache.entity_index_paths, entity.name)
+  end
+
+  defp get_index_from_catchall(entity, routes_cache) do
+    case routes_cache.entity_index_paths[:catchall] do
+      %{path: _} -> "/#{entity.name}"
+      _ -> nil
+    end
+  end
+
+  defp get_index_from_settings(entity) do
+    safe_get_setting("sitemap_entity_#{entity.name}_index_path")
+  end
+
+  defp get_fallback_index_path(entity) do
+    if safe_get_boolean_setting("sitemap_entities_auto_pattern", false) do
+      "/#{entity.name}"
+    else
+      nil
+    end
+  end
+
+  defp safe_get_boolean_setting(key, default) do
+    Settings.get_boolean_setting(key, default)
+  rescue
+    _ -> default
+  end
+
+  @doc """
+  Substitutes variables in a URL pattern with record data.
+  """
+  def build_path(pattern, record) do
+    pattern
+    |> String.replace(":slug", record.slug || to_string(record.uuid))
+    |> String.replace(":id", to_string(record.uuid))
+  end
+
+  @doc """
+  Adds a language prefix to a path (sitemap policy: prefix every language in multilang mode).
+
+  Used by `PhoenixKitEntities.SitemapSource` for hreflang-aware sitemap entries.
+  Consumers building public links should prefer `add_public_locale_prefix/2`, which
+  omits the prefix for the primary language (matching `PhoenixKit.Utils.Routes` conventions).
+  """
+  def build_path_with_language(path, language, _is_default \\ true) do
+    if language && !single_language_mode?() do
+      "/#{Languages.DialectMapper.extract_base(language)}#{path}"
+    else
+      path
+    end
+  end
+
+  @doc """
+  Adds a language prefix for public front-end URLs.
+
+  Policy:
+  - Single-language mode → no prefix
+  - Locale is `nil` → no prefix (caller did not request a specific locale)
+  - Locale matches the primary language → no prefix
+  - Otherwise → `/<base>` prefix
+
+  This matches the convention used by `PhoenixKit.Utils.Routes.path/2`
+  (default locale served from unprefixed URLs).
+  """
+  @spec add_public_locale_prefix(String.t(), String.t() | nil) :: String.t()
+  def add_public_locale_prefix(path, nil), do: path
+
+  def add_public_locale_prefix(path, locale) when is_binary(locale) do
+    cond do
+      single_language_mode?() ->
+        path
+
+      primary_language_base?(locale) ->
+        path
+
+      true ->
+        "/#{Languages.DialectMapper.extract_base(locale)}#{path}"
+    end
+  end
+
+  defp primary_language_base?(locale) do
+    primary =
+      try do
+        Multilang.primary_language()
+      rescue
+        _ -> nil
+      end
+
+    case primary do
+      nil ->
+        false
+
+      primary_code ->
+        Languages.DialectMapper.extract_base(primary_code) ==
+          Languages.DialectMapper.extract_base(locale)
+    end
+  end
+
+  @doc """
+  Checks if the system is in single language mode.
+  """
+  def single_language_mode? do
+    not Languages.enabled?() or length(Languages.get_enabled_languages()) <= 1
+  rescue
+    _ -> true
+  end
+
+  @doc """
+  Builds a full URL by prepending a base URL.
+
+  If `base_url` is nil, falls back to the `site_url` setting (or empty string).
+  """
+  def build_url(path, base_url \\ nil) do
+    base = base_url || safe_get_setting("site_url", "")
+    normalized_base = String.trim_trailing(base, "/")
+    "#{normalized_base}#{path}"
+  end
+end

--- a/lib/phoenix_kit_entities/url_resolver.ex
+++ b/lib/phoenix_kit_entities/url_resolver.ex
@@ -11,9 +11,21 @@ defmodule PhoenixKitEntities.UrlResolver do
   alias PhoenixKit.Settings
   alias PhoenixKit.Utils.Multilang
 
+  @type routes_cache :: %{
+          optional(:all_routes) => list(),
+          optional(:content_routes) => list(),
+          optional(:index_routes) => list(),
+          required(:entity_patterns) => map(),
+          required(:entity_index_paths) => map()
+        }
+
   @doc """
   Builds a cache of all routes for efficient lookups.
+
+  For hot loops (e.g. rendering a listing of records), build the cache once
+  via this function and pass it as `:routes_cache` to `EntityData.public_path/3`.
   """
+  @spec build_routes_cache() :: routes_cache()
   def build_routes_cache do
     routes = RouteResolver.get_routes()
 
@@ -114,8 +126,13 @@ defmodule PhoenixKitEntities.UrlResolver do
   end
 
   @doc """
-  Gets the URL pattern for an entity using cached routes.
+  Resolves the URL pattern for an entity using a pre-built routes cache.
+
+  Resolution chain: `entity.settings["sitemap_url_pattern"]` → router introspection
+  (explicit or catchall) → `sitemap_entity_<name>_pattern` setting → global
+  `sitemap_entities_pattern`. Returns `nil` if none match.
   """
+  @spec get_url_pattern_cached(map(), routes_cache()) :: String.t() | nil
   def get_url_pattern_cached(entity, routes_cache) do
     get_pattern_from_entity_settings(entity) ||
       get_pattern_from_cache(entity, routes_cache) ||
@@ -180,8 +197,12 @@ defmodule PhoenixKitEntities.UrlResolver do
   end
 
   @doc """
-  Gets the index path for an entity using cached routes.
+  Resolves the index-page path for an entity using a pre-built routes cache.
+
+  Used by the sitemap source to emit index entries (e.g. `/products` alongside
+  `/products/:slug`). Returns `nil` if no index path can be resolved.
   """
+  @spec get_index_path_cached(map(), routes_cache()) :: String.t() | nil
   def get_index_path_cached(entity, routes_cache) do
     get_index_from_entity_settings(entity) ||
       get_index_from_cache(entity, routes_cache) ||
@@ -230,8 +251,12 @@ defmodule PhoenixKitEntities.UrlResolver do
   end
 
   @doc """
-  Substitutes variables in a URL pattern with record data.
+  Substitutes `:slug` and `:id` placeholders in a URL pattern with record data.
+
+  `:slug` falls back to the record UUID when the slug is nil. Patterns without
+  placeholders are returned unchanged.
   """
+  @spec build_path(String.t(), map()) :: String.t()
   def build_path(pattern, record) do
     pattern
     |> String.replace(":slug", record.slug || to_string(record.uuid))
@@ -245,6 +270,7 @@ defmodule PhoenixKitEntities.UrlResolver do
   Consumers building public links should prefer `add_public_locale_prefix/2`, which
   omits the prefix for the primary language (matching `PhoenixKit.Utils.Routes` conventions).
   """
+  @spec build_path_with_language(String.t(), String.t() | nil, boolean()) :: String.t()
   def build_path_with_language(path, language, _is_default \\ true) do
     if language && !single_language_mode?() do
       "/#{Languages.DialectMapper.extract_base(language)}#{path}"
@@ -258,15 +284,20 @@ defmodule PhoenixKitEntities.UrlResolver do
 
   Policy:
   - Single-language mode → no prefix
-  - Locale is `nil` → no prefix (caller did not request a specific locale)
+  - Locale is `nil`, empty, or malformed → no prefix
   - Locale matches the primary language → no prefix
-  - Otherwise → `/<base>` prefix
+  - Otherwise → `/<base>` prefix (where `<base>` is a validated base code)
 
   This matches the convention used by `PhoenixKit.Utils.Routes.path/2`
   (default locale served from unprefixed URLs).
+
+  The base code is validated against `^[a-z]{2,3}$` before interpolation, so
+  caller-supplied locales (for example from request params) cannot inject
+  arbitrary path segments.
   """
   @spec add_public_locale_prefix(String.t(), String.t() | nil) :: String.t()
   def add_public_locale_prefix(path, nil), do: path
+  def add_public_locale_prefix(path, ""), do: path
 
   def add_public_locale_prefix(path, locale) when is_binary(locale) do
     cond do
@@ -277,8 +308,21 @@ defmodule PhoenixKitEntities.UrlResolver do
         path
 
       true ->
-        "/#{Languages.DialectMapper.extract_base(locale)}#{path}"
+        case safe_base_code(locale) do
+          nil -> path
+          base -> "/#{base}#{path}"
+        end
     end
+  end
+
+  # Extracts a base locale code and validates it against a strict allowlist
+  # of ISO 639-style lowercase alpha codes. Returns nil for anything else so
+  # the caller can fall back to an unprefixed URL rather than interpolate an
+  # attacker-controlled segment into the path.
+  defp safe_base_code(locale) do
+    base = Languages.DialectMapper.extract_base(locale)
+
+    if Regex.match?(~r/^[a-z]{2,3}$/, base), do: base, else: nil
   end
 
   defp primary_language_base?(locale) do
@@ -300,8 +344,12 @@ defmodule PhoenixKitEntities.UrlResolver do
   end
 
   @doc """
-  Checks if the system is in single language mode.
+  Returns `true` when the site is effectively single-language.
+
+  True when the Languages module is disabled or only one language is enabled;
+  also true if the lookup fails (defensive fallback).
   """
+  @spec single_language_mode?() :: boolean()
   def single_language_mode? do
     not Languages.enabled?() or length(Languages.get_enabled_languages()) <= 1
   rescue
@@ -313,6 +361,7 @@ defmodule PhoenixKitEntities.UrlResolver do
 
   If `base_url` is nil, falls back to the `site_url` setting (or empty string).
   """
+  @spec build_url(String.t(), String.t() | nil) :: String.t()
   def build_url(path, base_url \\ nil) do
     base = base_url || safe_get_setting("site_url", "")
     normalized_base = String.trim_trailing(base, "/")

--- a/lib/phoenix_kit_entities/web/data_form.ex
+++ b/lib/phoenix_kit_entities/web/data_form.ex
@@ -1145,6 +1145,7 @@ defmodule PhoenixKitEntities.Web.DataForm do
               type="submit"
               class="btn btn-primary"
               disabled={@readonly?}
+              phx-disable-with={gettext("Saving…")}
             >
               <%= if @data_record.uuid do %>
                 {gettext("Update %{entity}", entity: @entity.display_name)}
@@ -1476,6 +1477,7 @@ defmodule PhoenixKitEntities.Web.DataForm do
               type="submit"
               class="btn btn-primary"
               disabled={@readonly?}
+              phx-disable-with={gettext("Saving…")}
             >
               <.icon name="hero-check" class="w-4 h-4 mr-2" />
               <%= if @data_record.uuid do %>

--- a/lib/phoenix_kit_entities/web/data_form.ex
+++ b/lib/phoenix_kit_entities/web/data_form.ex
@@ -30,8 +30,8 @@ defmodule PhoenixKitEntities.Web.DataForm do
       params["locale"] || socket.assigns[:current_locale]
 
     # Edit mode with slug
-    entity = Entities.get_entity_by_name(entity_slug)
-    data_record = EntityData.get!(uuid)
+    entity = Entities.get_entity_by_name(entity_slug, lang: locale)
+    data_record = EntityData.get!(uuid, lang: locale)
     changeset = EntityData.change(data_record)
 
     mount_data_form(socket, entity, data_record, changeset, gettext("Edit Data"), locale)
@@ -43,8 +43,8 @@ defmodule PhoenixKitEntities.Web.DataForm do
       params["locale"] || socket.assigns[:current_locale]
 
     # Edit mode with ID (backwards compat)
-    entity = Entities.get_entity!(entity_uuid)
-    data_record = EntityData.get!(id)
+    entity = Entities.get_entity!(entity_uuid, lang: locale)
+    data_record = EntityData.get!(id, lang: locale)
     changeset = EntityData.change(data_record)
 
     mount_data_form(socket, entity, data_record, changeset, gettext("Edit Data"), locale)
@@ -56,7 +56,7 @@ defmodule PhoenixKitEntities.Web.DataForm do
       params["locale"] || socket.assigns[:current_locale]
 
     # Create mode with slug
-    entity = Entities.get_entity_by_name(entity_slug)
+    entity = Entities.get_entity_by_name(entity_slug, lang: locale)
     data_record = %EntityData{entity_uuid: entity.uuid}
     changeset = EntityData.change(data_record)
 
@@ -69,7 +69,7 @@ defmodule PhoenixKitEntities.Web.DataForm do
       params["locale"] || socket.assigns[:current_locale]
 
     # Create mode with ID (backwards compat)
-    entity = Entities.get_entity!(entity_uuid)
+    entity = Entities.get_entity!(entity_uuid, lang: locale)
     data_record = %EntityData{entity_uuid: entity.uuid}
     changeset = EntityData.change(data_record)
 
@@ -561,7 +561,8 @@ defmodule PhoenixKitEntities.Web.DataForm do
         {:noreply, socket}
 
       true ->
-        data_record = EntityData.get_data!(data_uuid)
+        locale = socket.assigns[:current_locale]
+        data_record = EntityData.get_data!(data_uuid, lang: locale)
         changeset = EntityData.change(data_record)
 
         socket =
@@ -606,7 +607,8 @@ defmodule PhoenixKitEntities.Web.DataForm do
 
   def handle_info({:entity_updated, entity_uuid}, socket) do
     if entity_uuid == socket.assigns.entity.uuid do
-      entity = Entities.get_entity!(entity_uuid)
+      locale = socket.assigns[:current_locale]
+      entity = Entities.get_entity!(entity_uuid, lang: locale)
 
       # If entity was archived or unpublished, redirect to entities list
       if entity.status != "published" do

--- a/lib/phoenix_kit_entities/web/data_form.ex
+++ b/lib/phoenix_kit_entities/web/data_form.ex
@@ -679,6 +679,9 @@ defmodule PhoenixKitEntities.Web.DataForm do
     end
   end
 
+  # Catch-all — ignore unexpected messages rather than crashing the socket.
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   # Strip lang_title/lang_slug from params — these are translation input names
   # that shouldn't be passed to the changeset as DB fields.
   defp strip_lang_params(params) do

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -16,9 +16,13 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
   alias PhoenixKitEntities.Events
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
+    # Set locale for LiveView process
+    locale =
+      params["locale"] || socket.assigns[:current_locale]
+
     project_title = Settings.get_project_title()
-    entities = Entities.list_entities()
+    entities = Entities.list_entities(lang: locale)
 
     # Subscribe to entity definition events so we know about creates/updates/deletes
     if connected?(socket) do
@@ -29,6 +33,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     # Set defaults only — entity resolution and data loading deferred to handle_params
     socket =
       socket
+      |> assign(:current_locale, locale)
       |> assign(:page_title, gettext("Data Navigator"))
       |> assign(:project_title, project_title)
       |> assign(:entities, entities)
@@ -87,13 +92,13 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
         {nil, nil}
 
       slug when is_binary(slug) ->
-        resolve_entity_by_slug(slug)
+        resolve_entity_by_slug(slug, socket.assigns[:current_locale])
     end
   end
 
   # Look up entity by slug/name
-  defp resolve_entity_by_slug(slug) do
-    case Entities.get_entity_by_name(slug) do
+  defp resolve_entity_by_slug(slug, locale) do
+    case Entities.get_entity_by_name(slug, lang: locale) do
       nil -> {nil, nil}
       entity -> {entity, entity.uuid}
     end
@@ -422,7 +427,8 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
   def handle_info({:entity_updated, entity_uuid}, socket) do
     # If the currently viewed entity was updated, check if it was archived
     if socket.assigns.selected_entity_uuid && entity_uuid == socket.assigns.selected_entity_uuid do
-      entity = Entities.get_entity!(entity_uuid)
+      locale = socket.assigns[:current_locale]
+      entity = Entities.get_entity!(entity_uuid, lang: locale)
 
       # If entity was archived or unpublished, redirect to entities list
       if entity.status != "published" do
@@ -527,7 +533,9 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
 
     # Pass sort_mode from the already-loaded entity to avoid redundant DB lookups
     sort_opts =
-      if entity, do: [sort_mode: Entities.get_sort_mode(entity)], else: []
+      if entity,
+        do: [sort_mode: Entities.get_sort_mode(entity), lang: socket.assigns[:current_locale]],
+        else: [lang: socket.assigns[:current_locale]]
 
     entity_data_records =
       fetch_records(entity_uuid, status, sort_opts)
@@ -570,8 +578,10 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
   end
 
   defp refresh_entities_and_data(socket) do
+    locale = socket.assigns[:current_locale]
+
     socket
-    |> assign(:entities, Entities.list_entities())
+    |> assign(:entities, Entities.list_entities(lang: locale))
     |> refresh_data_stats()
     |> apply_filters()
   end

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -485,6 +485,9 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     {:noreply, apply_filters(socket)}
   end
 
+  # Catch-all — ignore unexpected messages rather than crashing the socket.
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   # Helper Functions
 
   defp build_base_path(nil), do: "/admin/entities"

--- a/lib/phoenix_kit_entities/web/data_view.ex
+++ b/lib/phoenix_kit_entities/web/data_view.ex
@@ -20,8 +20,8 @@ defmodule PhoenixKitEntities.Web.DataView do
     locale =
       params["locale"] || socket.assigns[:current_locale]
 
-    entity = Entities.get_entity_by_name(entity_slug)
-    data_record = EntityData.get!(id)
+    entity = Entities.get_entity_by_name(entity_slug, lang: locale)
+    data_record = EntityData.get!(id, lang: locale)
 
     mount_data_view(socket, entity, data_record, locale)
   end
@@ -30,8 +30,8 @@ defmodule PhoenixKitEntities.Web.DataView do
     locale =
       params["locale"] || socket.assigns[:current_locale]
 
-    entity = Entities.get_entity!(entity_uuid)
-    data_record = EntityData.get!(id)
+    entity = Entities.get_entity!(entity_uuid, lang: locale)
+    data_record = EntityData.get!(id, lang: locale)
 
     mount_data_view(socket, entity, data_record, locale)
   end

--- a/lib/phoenix_kit_entities/web/entities.ex
+++ b/lib/phoenix_kit_entities/web/entities.ex
@@ -24,7 +24,7 @@ defmodule PhoenixKitEntities.Web.Entities do
       |> assign(:page_title, gettext("Entities"))
       |> assign(:project_title, project_title)
       |> assign(:view_mode, "table")
-      |> assign(:entities, Entities.list_entities())
+      |> assign(:entities, Entities.list_entities(lang: locale))
 
     {:ok, socket}
   end
@@ -49,13 +49,14 @@ defmodule PhoenixKitEntities.Web.Entities do
   end
 
   def handle_event("archive_entity", %{"uuid" => uuid}, socket) do
-    entity = Entities.get_entity!(uuid)
+    locale = socket.assigns[:current_locale]
+    entity = Entities.get_entity!(uuid, lang: locale)
 
     case Entities.update_entity(entity, %{status: "archived"}) do
       {:ok, _entity} ->
         socket =
           socket
-          |> assign(:entities, Entities.list_entities())
+          |> assign(:entities, Entities.list_entities(lang: locale))
           |> put_flash(
             :info,
             gettext("Entity '%{name}' archived successfully", name: entity.display_name)
@@ -69,13 +70,14 @@ defmodule PhoenixKitEntities.Web.Entities do
   end
 
   def handle_event("restore_entity", %{"uuid" => uuid}, socket) do
-    entity = Entities.get_entity!(uuid)
+    locale = socket.assigns[:current_locale]
+    entity = Entities.get_entity!(uuid, lang: locale)
 
     case Entities.update_entity(entity, %{status: "published"}) do
       {:ok, _entity} ->
         socket =
           socket
-          |> assign(:entities, Entities.list_entities())
+          |> assign(:entities, Entities.list_entities(lang: locale))
           |> put_flash(
             :info,
             gettext("Entity '%{name}' restored successfully", name: entity.display_name)
@@ -93,7 +95,8 @@ defmodule PhoenixKitEntities.Web.Entities do
   @impl true
   def handle_info({event, _entity_uuid}, socket)
       when event in [:entity_created, :entity_updated, :entity_deleted] do
-    {:noreply, assign(socket, :entities, Entities.list_entities())}
+    {:noreply,
+     assign(socket, :entities, Entities.list_entities(lang: socket.assigns[:current_locale]))}
   end
 
   # Helper Functions

--- a/lib/phoenix_kit_entities/web/entities.ex
+++ b/lib/phoenix_kit_entities/web/entities.ex
@@ -99,6 +99,9 @@ defmodule PhoenixKitEntities.Web.Entities do
      assign(socket, :entities, Entities.list_entities(lang: socket.assigns[:current_locale]))}
   end
 
+  # Catch-all — ignore unexpected messages rather than crashing the socket.
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   # Helper Functions
 
   # Extracts the base path (without query string) from the current URL,

--- a/lib/phoenix_kit_entities/web/entities_settings.ex
+++ b/lib/phoenix_kit_entities/web/entities_settings.ex
@@ -535,6 +535,9 @@ defmodule PhoenixKitEntities.Web.EntitiesSettings do
     {:noreply, socket}
   end
 
+  # Catch-all — ignore unexpected messages rather than crashing the socket.
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   # Private Functions
 
   defp build_changeset(settings, action \\ nil) do

--- a/lib/phoenix_kit_entities/web/entity_form.ex
+++ b/lib/phoenix_kit_entities/web/entity_form.ex
@@ -1633,6 +1633,7 @@ defmodule PhoenixKitEntities.Web.EntityForm do
               type="submit"
               class="btn btn-primary"
               disabled={!@changeset.valid? or @readonly?}
+              phx-disable-with={gettext("Saving…")}
             >
               {if @entity.uuid, do: gettext("Update Entity"), else: gettext("Create Entity")}
             </button>
@@ -2775,6 +2776,7 @@ defmodule PhoenixKitEntities.Web.EntityForm do
               type="submit"
               class="btn btn-primary"
               disabled={!@changeset.valid? or @readonly?}
+              phx-disable-with={gettext("Saving…")}
             >
               {if @entity.uuid, do: gettext("Update Entity"), else: gettext("Create Entity")}
             </button>

--- a/lib/phoenix_kit_entities/web/entity_form.ex
+++ b/lib/phoenix_kit_entities/web/entity_form.ex
@@ -1052,6 +1052,9 @@ defmodule PhoenixKitEntities.Web.EntityForm do
     end
   end
 
+  # Catch-all — ignore unexpected messages rather than crashing the socket.
+  def handle_info(_message, socket), do: {:noreply, socket}
+
   # Helper Functions
 
   defp handle_remote_entity_update(socket, entity_uuid) do

--- a/test/phoenix_kit_entities/entity_data_url_test.exs
+++ b/test/phoenix_kit_entities/entity_data_url_test.exs
@@ -91,6 +91,79 @@ defmodule PhoenixKitEntities.EntityDataUrlTest do
     end
   end
 
+  describe "public_path/3 — translated slugs" do
+    test "uses secondary-language _slug override when locale is given" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+
+      record = %{
+        uuid: "uuid-1",
+        slug: "my-item",
+        data: %{
+          "en-US" => %{"_slug" => "my-item"},
+          "es-ES" => %{"_slug" => "mi-articulo"}
+        }
+      }
+
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, locale: "es-ES", routes_cache: cache) ==
+               "/p/mi-articulo"
+    end
+
+    test "falls back to primary slug when locale has no _slug override" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+
+      record = %{
+        uuid: "uuid-1",
+        slug: "my-item",
+        data: %{"es-ES" => %{"name" => "Mi Artículo"}}
+      }
+
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, locale: "es-ES", routes_cache: cache) ==
+               "/p/my-item"
+    end
+
+    test "ignores _slug override when no locale is given" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+
+      record = %{
+        uuid: "uuid-1",
+        slug: "my-item",
+        data: %{"es-ES" => %{"_slug" => "mi-articulo"}}
+      }
+
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) == "/p/my-item"
+    end
+
+    test "empty _slug override falls back to primary" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+
+      record = %{
+        uuid: "uuid-1",
+        slug: "my-item",
+        data: %{"es-ES" => %{"_slug" => ""}}
+      }
+
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, locale: "es-ES", routes_cache: cache) ==
+               "/p/my-item"
+    end
+
+    test "nil data map does not crash" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+      record = %{uuid: "uuid-1", slug: "my-item", data: nil}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, locale: "es-ES", routes_cache: cache) ==
+               "/p/my-item"
+    end
+  end
+
   describe "public_path/3 — defensive inputs" do
     test "nil settings on entity uses fallback pattern" do
       entity = %{name: "product", settings: nil}

--- a/test/phoenix_kit_entities/entity_data_url_test.exs
+++ b/test/phoenix_kit_entities/entity_data_url_test.exs
@@ -1,0 +1,130 @@
+defmodule PhoenixKitEntities.EntityDataUrlTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKitEntities.EntityData
+
+  # These tests run without Languages enabled (single-language mode),
+  # so `add_public_locale_prefix/2` never adds a prefix regardless of locale.
+  # Prefix behavior is covered in tests that mock Languages (integration).
+
+  describe "public_path/3 — pattern resolution" do
+    test "uses entity.settings['sitemap_url_pattern']" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/shop/:slug"}}
+      record = %{uuid: "uuid-1", slug: "my-item"}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) ==
+               "/shop/my-item"
+    end
+
+    test "uses router-introspected pattern when no entity setting" do
+      entity = %{name: "product", settings: %{}}
+      record = %{uuid: "uuid-1", slug: "my-item"}
+
+      cache = %{
+        entity_patterns: %{"product" => "/products/:slug", :catchall => nil},
+        entity_index_paths: %{}
+      }
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) ==
+               "/products/my-item"
+    end
+
+    test "falls back to /<entity_name>/:slug when no pattern is resolvable" do
+      entity = %{name: "product", settings: %{}}
+      record = %{uuid: "uuid-1", slug: "my-item"}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) ==
+               "/product/my-item"
+    end
+
+    test "slug falls back to uuid when missing" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+      record = %{uuid: "uuid-abc", slug: nil}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) ==
+               "/p/uuid-abc"
+    end
+
+    test "substitutes :id placeholder" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:id"}}
+      record = %{uuid: "uuid-abc", slug: "ignored"}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) ==
+               "/p/uuid-abc"
+    end
+
+    test "pattern with literal segments works" do
+      entity = %{name: "post", settings: %{"sitemap_url_pattern" => "/blog/2025/:slug"}}
+      record = %{uuid: "uuid-1", slug: "hello"}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) ==
+               "/blog/2025/hello"
+    end
+  end
+
+  describe "public_path/3 — locale prefix (single-language mode)" do
+    test "locale is ignored when single-language mode is active" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+      record = %{uuid: "uuid-1", slug: "item"}
+      cache = empty_cache()
+
+      # In tests, Languages is disabled → single_language_mode? is true → no prefix
+      assert EntityData.public_path(entity, record, locale: "es-ES", routes_cache: cache) ==
+               "/p/item"
+
+      assert EntityData.public_path(entity, record, locale: "ru", routes_cache: cache) ==
+               "/p/item"
+    end
+
+    test "nil locale returns bare path" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+      record = %{uuid: "uuid-1", slug: "item"}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, locale: nil, routes_cache: cache) ==
+               "/p/item"
+    end
+  end
+
+  describe "public_url/3" do
+    test "prepends base_url option" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+      record = %{uuid: "uuid-1", slug: "item"}
+      cache = empty_cache()
+
+      assert EntityData.public_url(entity, record,
+               base_url: "https://site.com",
+               routes_cache: cache
+             ) == "https://site.com/p/item"
+    end
+
+    test "trailing slash on base_url is trimmed" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+      record = %{uuid: "uuid-1", slug: "item"}
+      cache = empty_cache()
+
+      assert EntityData.public_url(entity, record,
+               base_url: "https://site.com/",
+               routes_cache: cache
+             ) == "https://site.com/p/item"
+    end
+
+    test "no base_url falls back to site_url setting (empty default)" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}
+      record = %{uuid: "uuid-1", slug: "item"}
+      cache = empty_cache()
+
+      # No site_url configured in tests, so base is "" and only the path remains.
+      assert EntityData.public_url(entity, record, routes_cache: cache) == "/p/item"
+    end
+  end
+
+  defp empty_cache do
+    %{entity_patterns: %{catchall: nil}, entity_index_paths: %{}}
+  end
+end

--- a/test/phoenix_kit_entities/entity_data_url_test.exs
+++ b/test/phoenix_kit_entities/entity_data_url_test.exs
@@ -91,6 +91,26 @@ defmodule PhoenixKitEntities.EntityDataUrlTest do
     end
   end
 
+  describe "public_path/3 — defensive inputs" do
+    test "nil settings on entity uses fallback pattern" do
+      entity = %{name: "product", settings: nil}
+      record = %{uuid: "uuid-1", slug: "item"}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) ==
+               "/product/item"
+    end
+
+    test "empty settings map on entity uses fallback pattern" do
+      entity = %{name: "product", settings: %{}}
+      record = %{uuid: "uuid-1", slug: "item"}
+      cache = empty_cache()
+
+      assert EntityData.public_path(entity, record, routes_cache: cache) ==
+               "/product/item"
+    end
+  end
+
   describe "public_url/3" do
     test "prepends base_url option" do
       entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/p/:slug"}}

--- a/test/phoenix_kit_entities/entity_multilang_test.exs
+++ b/test/phoenix_kit_entities/entity_multilang_test.exs
@@ -1,0 +1,63 @@
+defmodule PhoenixKitEntities.EntityMultilangTest do
+  use ExUnit.Case, async: true
+  alias PhoenixKitEntities, as: Entities
+
+  describe "resolve_language/2" do
+    test "resolves entity metadata from settings.translations" do
+      entity = %Entities{
+        display_name: "Product",
+        display_name_plural: "Products",
+        description: "Standard product",
+        settings: %{
+          "translations" => %{
+            "es-ES" => %{
+              "display_name" => "Producto",
+              "display_name_plural" => "Productos",
+              "description" => "Producto estándar"
+            }
+          }
+        }
+      }
+
+      resolved = Entities.resolve_language(entity, "es-ES")
+
+      assert resolved.display_name == "Producto"
+      assert resolved.display_name_plural == "Productos"
+      assert resolved.description == "Producto estándar"
+    end
+
+    test "falls back to default fields when translation is missing" do
+      entity = %Entities{
+        display_name: "Product",
+        settings: %{"translations" => %{}}
+      }
+
+      resolved = Entities.resolve_language(entity, "es-ES")
+      assert resolved.display_name == "Product"
+    end
+
+    test "falls back to default fields when lang is nil" do
+      entity = %Entities{display_name: "Product"}
+      resolved = Entities.resolve_language(entity, nil)
+      assert resolved.display_name == "Product"
+    end
+  end
+
+  describe "maybe_resolve_lang/2" do
+    test "resolves when lang option is present" do
+      entity = %Entities{
+        display_name: "Product",
+        settings: %{"translations" => %{"es-ES" => %{"display_name" => "Producto"}}}
+      }
+
+      resolved = Entities.maybe_resolve_lang(entity, lang: "es-ES")
+      assert resolved.display_name == "Producto"
+    end
+
+    test "skips resolution when lang is missing" do
+      entity = %Entities{display_name: "Product"}
+      resolved = Entities.maybe_resolve_lang(entity, [])
+      assert resolved.display_name == "Product"
+    end
+  end
+end

--- a/test/phoenix_kit_entities/entity_multilang_test.exs
+++ b/test/phoenix_kit_entities/entity_multilang_test.exs
@@ -59,5 +59,88 @@ defmodule PhoenixKitEntities.EntityMultilangTest do
       resolved = Entities.maybe_resolve_lang(entity, [])
       assert resolved.display_name == "Product"
     end
+
+    test "skips resolution when lang is nil in opts" do
+      entity = %Entities{display_name: "Product"}
+      resolved = Entities.maybe_resolve_lang(entity, lang: nil)
+      assert resolved.display_name == "Product"
+    end
+  end
+
+  describe "resolve_language/2 — defensive handling" do
+    test "no settings (nil)" do
+      entity = %Entities{display_name: "Product", settings: nil}
+      assert Entities.resolve_language(entity, "es-ES").display_name == "Product"
+    end
+
+    test "empty settings" do
+      entity = %Entities{display_name: "Product", settings: %{}}
+      assert Entities.resolve_language(entity, "es-ES").display_name == "Product"
+    end
+
+    test "translations map present but target locale missing" do
+      entity = %Entities{
+        display_name: "Product",
+        settings: %{"translations" => %{"fr-FR" => %{"display_name" => "Produit"}}}
+      }
+
+      assert Entities.resolve_language(entity, "es-ES").display_name == "Product"
+    end
+
+    test "per-field missing — mixed resolution" do
+      entity = %Entities{
+        display_name: "Product",
+        display_name_plural: "Products",
+        description: "English description",
+        settings: %{
+          "translations" => %{
+            "es-ES" => %{"display_name" => "Producto"}
+            # plural + description intentionally missing
+          }
+        }
+      }
+
+      resolved = Entities.resolve_language(entity, "es-ES")
+      assert resolved.display_name == "Producto"
+      # Missing translations fall back to primary values
+      assert resolved.display_name_plural == "Products"
+      assert resolved.description == "English description"
+    end
+
+    test "empty-string override falls back to primary" do
+      entity = %Entities{
+        display_name: "Product",
+        settings: %{"translations" => %{"es-ES" => %{"display_name" => ""}}}
+      }
+
+      assert Entities.resolve_language(entity, "es-ES").display_name == "Product"
+    end
+  end
+
+  describe "resolve_languages/2" do
+    test "empty list" do
+      assert Entities.resolve_languages([], "es-ES") == []
+    end
+
+    test "nil locale is a no-op" do
+      entity = %Entities{display_name: "Product"}
+      assert Entities.resolve_languages([entity], nil) == [entity]
+    end
+
+    test "resolves every element" do
+      entities = [
+        %Entities{
+          display_name: "Product",
+          settings: %{"translations" => %{"es-ES" => %{"display_name" => "Producto"}}}
+        },
+        %Entities{
+          display_name: "Article",
+          settings: %{"translations" => %{"es-ES" => %{"display_name" => "Artículo"}}}
+        }
+      ]
+
+      resolved = Entities.resolve_languages(entities, "es-ES")
+      assert Enum.map(resolved, & &1.display_name) == ["Producto", "Artículo"]
+    end
   end
 end

--- a/test/phoenix_kit_entities/sidebar_cache_test.exs
+++ b/test/phoenix_kit_entities/sidebar_cache_test.exs
@@ -1,0 +1,38 @@
+defmodule PhoenixKitEntities.SidebarCacheTest do
+  use ExUnit.Case, async: false
+
+  alias PhoenixKit.Dashboard.Registry, as: DashboardRegistry
+
+  @entities_cache_key :entities_children_cache
+
+  describe "invalidate_entities_cache/0" do
+    setup do
+      # Ensure the DashboardRegistry ETS table exists for this test.
+      # If the Registry is not initialized, skip — cache logic is a no-op in that case.
+      if DashboardRegistry.initialized?() do
+        :ok
+      else
+        {:ok, _} = start_supervised(DashboardRegistry)
+        :ok
+      end
+
+      :ok
+    end
+
+    test "match_delete clears all per-locale cache entries" do
+      table = DashboardRegistry.ets_table()
+      now = System.monotonic_time(:millisecond)
+
+      # Seed cache entries for multiple locales
+      :ets.insert(table, {{@entities_cache_key, "en-US"}, [:seeded_en], now})
+      :ets.insert(table, {{@entities_cache_key, "es-ES"}, [:seeded_es], now})
+      :ets.insert(table, {{@entities_cache_key, nil}, [:seeded_none], now})
+
+      assert length(:ets.match(table, {{@entities_cache_key, :_}, :_, :_})) == 3
+
+      assert :ok = PhoenixKitEntities.invalidate_entities_cache()
+
+      assert :ets.match(table, {{@entities_cache_key, :_}, :_, :_}) == []
+    end
+  end
+end

--- a/test/phoenix_kit_entities/url_resolver_test.exs
+++ b/test/phoenix_kit_entities/url_resolver_test.exs
@@ -1,0 +1,125 @@
+defmodule PhoenixKitEntities.UrlResolverTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKitEntities.UrlResolver
+
+  describe "build_path/2" do
+    test "substitutes :slug" do
+      record = %{uuid: "018e3c4a-9f6b-7890-abcd-ef1234567890", slug: "my-item"}
+      assert UrlResolver.build_path("/products/:slug", record) == "/products/my-item"
+    end
+
+    test "substitutes :id" do
+      record = %{uuid: "018e3c4a-9f6b-7890-abcd-ef1234567890", slug: "my-item"}
+
+      assert UrlResolver.build_path("/items/:id", record) ==
+               "/items/018e3c4a-9f6b-7890-abcd-ef1234567890"
+    end
+
+    test "substitutes both :slug and :id in one pattern" do
+      record = %{uuid: "018e3c4a-9f6b-7890-abcd-ef1234567890", slug: "my-item"}
+
+      assert UrlResolver.build_path("/shop/:slug/:id", record) ==
+               "/shop/my-item/018e3c4a-9f6b-7890-abcd-ef1234567890"
+    end
+
+    test "slug falls back to uuid when missing" do
+      record = %{uuid: "018e3c4a-9f6b-7890-abcd-ef1234567890", slug: nil}
+
+      assert UrlResolver.build_path("/products/:slug", record) ==
+               "/products/018e3c4a-9f6b-7890-abcd-ef1234567890"
+    end
+
+    test "handles complex patterns with literal segments" do
+      record = %{uuid: "uuid123", slug: "my-post"}
+
+      assert UrlResolver.build_path("/blog/2025/:slug", record) ==
+               "/blog/2025/my-post"
+    end
+  end
+
+  describe "get_url_pattern_cached/2 — precedence" do
+    test "entity.settings['sitemap_url_pattern'] wins" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/shop/:slug"}}
+
+      cache = %{
+        entity_patterns: %{"product" => "/ignored/:slug", :catchall => nil},
+        entity_index_paths: %{}
+      }
+
+      assert UrlResolver.get_url_pattern_cached(entity, cache) == "/shop/:slug"
+    end
+
+    test "router introspection wins over global settings" do
+      entity = %{name: "product", settings: %{}}
+
+      cache = %{
+        entity_patterns: %{"product" => "/products/:slug", :catchall => nil},
+        entity_index_paths: %{}
+      }
+
+      assert UrlResolver.get_url_pattern_cached(entity, cache) == "/products/:slug"
+    end
+
+    test "catchall route rewrites entity_name placeholder" do
+      entity = %{name: "widget", settings: %{}}
+
+      cache = %{
+        entity_patterns: %{catchall: %{path: "/:entity_name/:slug"}},
+        entity_index_paths: %{}
+      }
+
+      assert UrlResolver.get_url_pattern_cached(entity, cache) == "/widget/:slug"
+    end
+
+    test "returns nil when no route, no settings" do
+      entity = %{name: "product", settings: %{}}
+      cache = %{entity_patterns: %{catchall: nil}, entity_index_paths: %{}}
+
+      assert UrlResolver.get_url_pattern_cached(entity, cache) == nil
+    end
+
+    test "empty settings pattern is ignored, falls through to router" do
+      entity = %{name: "product", settings: %{"sitemap_url_pattern" => ""}}
+
+      cache = %{
+        entity_patterns: %{"product" => "/products/:slug", :catchall => nil},
+        entity_index_paths: %{}
+      }
+
+      assert UrlResolver.get_url_pattern_cached(entity, cache) == "/products/:slug"
+    end
+  end
+
+  describe "add_public_locale_prefix/2" do
+    test "nil locale returns path unchanged" do
+      assert UrlResolver.add_public_locale_prefix("/products/my-item", nil) ==
+               "/products/my-item"
+    end
+
+    test "single-language mode returns path unchanged even with a locale" do
+      # Languages module is not enabled in the test environment, so
+      # single_language_mode?/0 returns true and the prefix is skipped.
+      assert UrlResolver.add_public_locale_prefix("/products/my-item", "es-ES") ==
+               "/products/my-item"
+    end
+  end
+
+  describe "build_url/2" do
+    test "prepends base_url" do
+      assert UrlResolver.build_url("/path", "https://example.com") ==
+               "https://example.com/path"
+    end
+
+    test "trims trailing slash from base_url" do
+      assert UrlResolver.build_url("/path", "https://example.com/") ==
+               "https://example.com/path"
+    end
+  end
+
+  describe "single_language_mode?/0" do
+    test "returns true when Languages module is disabled" do
+      assert UrlResolver.single_language_mode?() == true
+    end
+  end
+end

--- a/test/phoenix_kit_entities/url_resolver_test.exs
+++ b/test/phoenix_kit_entities/url_resolver_test.exs
@@ -97,10 +97,36 @@ defmodule PhoenixKitEntities.UrlResolverTest do
                "/products/my-item"
     end
 
+    test "empty locale returns path unchanged" do
+      assert UrlResolver.add_public_locale_prefix("/products/my-item", "") ==
+               "/products/my-item"
+    end
+
     test "single-language mode returns path unchanged even with a locale" do
       # Languages module is not enabled in the test environment, so
       # single_language_mode?/0 returns true and the prefix is skipped.
       assert UrlResolver.add_public_locale_prefix("/products/my-item", "es-ES") ==
+               "/products/my-item"
+    end
+
+    # These tests exercise the safe_base_code/1 guard against path injection
+    # from caller-supplied locales (e.g. raw request params). The guard runs
+    # before single_language_mode?/0, so even in tests without the Languages
+    # module these inputs must never leak into the prefix.
+    test "rejects locale with path-traversal attempt" do
+      # Even if a malicious locale got past single-language-mode check,
+      # safe_base_code would strip it — verified by the no-prefix output.
+      assert UrlResolver.add_public_locale_prefix("/products/my-item", "../etc/passwd") ==
+               "/products/my-item"
+    end
+
+    test "rejects locale containing slashes" do
+      assert UrlResolver.add_public_locale_prefix("/products/my-item", "en/admin") ==
+               "/products/my-item"
+    end
+
+    test "rejects locale with non-alpha chars" do
+      assert UrlResolver.add_public_locale_prefix("/products/my-item", "en123") ==
                "/products/my-item"
     end
   end


### PR DESCRIPTION
Closes #6
Closes #7

## Summary

Bundles two related issues:

- **#6** — adds `EntityData.public_path/3` and `public_url/3` so parent apps stop hand-wiring `\"/#{record.slug}\"` and dropping the locale prefix on `/:locale/...` routes.
- **#7** — the entity-definition translation API has existed since 0.1.0 (`settings[\"translations\"]`, `get/set/remove_entity_translation`, `resolve_language/2`, `lang:` opt on every query function), but nothing inside the module used it. The admin LiveViews and sidebar read raw primary-language columns, which is why `/ru/page` in the Hydroforce install still showed English titles. This PR closes the loop by dogfooding the API and documenting it.

## Issue #6 — Public URL helpers

- New `PhoenixKitEntities.UrlResolver` module extracted from `SitemapSource`: router/URL pattern resolution, placeholder substitution, and URL building. Sitemap now delegates to it and keeps its own \"prefix every language\" policy via `UrlResolver.build_path_with_language/3`.
- `EntityData.public_path/3` and `public_url/3` use the shared resolver plus a \"no prefix for default locale\" policy (`UrlResolver.add_public_locale_prefix/2`) matching `PhoenixKit.Utils.Routes.path/2` conventions:
  - `:locale` omitted / `nil` → no prefix
  - Single-language mode → no prefix
  - Primary language → no prefix
  - Other locales → `/es/...`, `/ru/...`
- Pattern chain: `entity.settings[\"sitemap_url_pattern\"]` → router introspection (explicit or catchall) → `sitemap_entity_<name>_pattern` → `sitemap_entities_pattern` → fallback `/<entity_name>/:slug`.
- `:routes_cache` opt for batch use; `:base_url` opt on `public_url/3` overrides the `site_url` setting.
- Settings lookups in `UrlResolver` wrapped in `try/rescue` so URL builders degrade gracefully when the Settings table is unavailable.

## Issue #7 — Multilang consistency + docs

- `list_entity_summaries/1` — accepts `:lang`, selects `settings`, resolves via `resolve_language/2`.
- `entities_children/1` — reads `Gettext.get_locale(PhoenixKitWeb.Gettext)` at render time and passes it through. Cache key is `{@entities_cache_key, locale}`. `invalidate_entities_cache/0` now match-deletes every locale variant (previously only cleared the single atom key, leaving stale per-locale rows behind).
- `resolve_language/2` and `resolve_languages/2` — nil-safe guards, `@spec` updated to `String.t() | nil` so consumers can thread an optional locale without a pre-check.
- Admin LiveViews dogfood `lang: current_locale` on entity lookups: `Web.Entities`, `Web.DataNavigator`, `Web.DataForm`, `Web.DataView`. `EntityForm` and `EntitiesSettings` deliberately keep raw primary-language reads — those surfaces manage canonical identity, not localized presentation.
- README \"Multi-language support\" section rewritten to document entity-definition translations, the `lang:` opt across every query function, `set/get_entity_translation`, and the translatable-fields list. New \"Public URL resolution\" section covers `public_path/3` / `public_url/3`.
- OVERVIEW.md references `UrlResolver` and the new `EntityData` public URL helpers.

## Tests

New unit tests (all pass; no DB required):

- `url_resolver_test.exs` — placeholder substitution, pattern precedence (entity settings > router > catchall > settings fallback), `add_public_locale_prefix/2`, `build_url/2`, single-language-mode detection.
- `entity_data_url_test.exs` — `public_path/3` / `public_url/3` scenarios including slug-falls-back-to-uuid, locale handling in single-language mode, `base_url` override.
- `entity_multilang_test.exs` — `resolve_language/2` across all three translatable fields + nil-locale guard.
- `sidebar_cache_test.exs` — verifies `invalidate_entities_cache/0` clears every per-locale cache entry via `match_delete`.

`mix precommit` passes: format ✅, credo --strict ✅, dialyzer (0 errors) ✅.

## Out of scope (follow-ups)

- **Translated slugs for `public_path/3`.** `EntityData.secondary_slug_exists?/4` already hints at per-language slug support in the data model; `public_path/3` v1 uses `record.slug` (primary). If/when secondary-language slugs ship as a first-class field, `public_path/3` should honor them.
- **Parent-app migration.** Apps still calling `list_entities()` need to switch to `list_entities(lang: locale)` themselves. The `lang:` opt has existed since 0.1.0 — this PR closes the _documentation_ gap, not consumer code.
- **`guides/entities-guide.md` refresh.** The guide still uses the pre-extraction `PhoenixKit.Modules.Entities` namespace and doesn't cover multilang or public URLs. Full rewrite deserves its own PR.
- **Core `dynamic_children.(scope)` → `dynamic_children.(scope, locale)`.** Would let us drop the `Gettext.get_locale/1` read; a future phoenix_kit core PR.

## Commit history

1. `Add locale-aware public URL helpers for entity records (#6)` — `UrlResolver` + `public_path/3` + `public_url/3` + tests.
2. `Apply entity definition translations across admin UI and sidebar (#7)` — `list_entity_summaries` + sidebar cache + admin dogfood + docs + tests.

Two commits kept separate by issue so review/revert is granular.

## Test plan

- [ ] `mix test --exclude integration` passes locally
- [ ] `mix precommit` clean
- [ ] Manually: enable Languages with `en-US` + `es-ES`, add an entity, set a translation for `display_name_plural`, switch admin locale → sidebar, entities list, data navigator header all reflect the translated label
- [ ] Manually: call `EntityData.public_path(entity, record, locale: \"es-ES\")` on a configured entity → expect `/es/...` prefix
- [ ] Manually: same call with `locale: \"en-US\"` (primary) → expect unprefixed path