### PR TITLE
Drag-and-drop reorder for entities and records + quality sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,9 +166,34 @@ and Settings.
   `data` and `metadata` field values
 - Both use UUIDv7 primary keys
 - Migrations are owned by core PhoenixKit (`V17` creates the tables;
-  `V40` / `V58` / `V67` / `V74` / `V81` evolve them). No module-owned
-  DDL anywhere — the host app runs `PhoenixKit.Migrations.up()` and
-  gets everything.
+  `V40` / `V58` / `V67` / `V74` / `V81` / `V108` evolve them). No
+  module-owned DDL anywhere — the host app runs
+  `PhoenixKit.Migrations.up()` and gets everything.
+
+### Drag-and-drop reorder API
+
+Both lists carry an integer `position` column (V81 for entity_data,
+V108 for entities) that drives manual sort.
+
+- `Entities.reorder_entities(ordered_uuids, opts)` — re-indexes the
+  entity definitions to positions `1..N`. Logs `entity.reordered`,
+  broadcasts `:entity_updated` for sidebar cache invalidation. Capped
+  at 1000 uuids; oversized rejects with `{:error, :too_many_uuids}`
+  AND audit-logs the rejection (`db_pending: true`,
+  `rejected: "too_many_uuids"`).
+- `EntityData.reorder(entity_uuid, ordered_uuids, opts)` — re-indexes
+  records within one entity. The DB layer enforces the entity_uuid
+  scope so a stray cross-entity uuid in the input list cannot rewrite
+  positions in the wrong scope (every per-uuid `update_all`
+  AND-filters on `entity_uuid`). Same 1000-cap + dedup behavior.
+- Both functions log on `:ok` AND `:error` branches; the error branch
+  carries `db_pending: true` so the audit trail covers user-initiated
+  intent even when the transaction rolls back.
+- LV call sites (`Web.Entities`, `Web.DataNavigator`) thread
+  `actor_opts(socket)` so the activity rows pin `actor_uuid`. The
+  DataNavigator auto-flips `sort_mode` to `"manual"` on the first
+  drag and emits a `Logger.warning` so ops can see the implicit
+  setting change.
 
 ### Activity Logging Pattern
 

--- a/README.md
+++ b/README.md
@@ -210,10 +210,25 @@ EntityData.get_by_slug(entity.uuid, "iphone-15")
 
 ### Manual ordering
 
-Entities can use auto sort (by creation date) or manual sort (by position). Configure via the entity's `settings`:
+Both **entity definitions** (the list at `/admin/entities`) and **data records** within an entity carry an integer `position` column managed by core's V81 / V108 migrations. Two reorder surfaces are exposed:
+
+- `Entities.reorder_entities(ordered_uuids, opts \\ [])` — re-indexes the entity list to positions `1..N` in the order given. Logs `entity.reordered` (PII-safe — count + first uuid only). Broadcasts `:entity_updated` so the dashboard sidebar's entity-summaries cache invalidates immediately. Capped at 1000 uuids; oversized payloads return `{:error, :too_many_uuids}` and still log a `db_pending` audit row so the rejected attempt is attributable.
+- `EntityData.reorder(entity_uuid, ordered_uuids, opts \\ [])` — re-indexes the records of one entity. Internally enforces the `entity_uuid` scope at the DB layer so a stray cross-entity uuid in the input list cannot rewrite positions in the wrong scope. Same 1000-uuid cap and audit semantics. Broadcasts `:data_reordered` for live LV refresh.
+
+Each entity carries a `sort_mode` setting (`"auto"` — by creation date — or `"manual"` — by `position`). Configure via:
 
 ```elixir
 PhoenixKitEntities.update_sort_mode(entity, "manual")
+```
+
+The DataNavigator admin LV auto-flips an entity to `"manual"` on the first drag (otherwise the visible reorder would snap back on the next refresh) and emits a `Logger.warning` so ops can see the implicit setting change. To opt entities-list reorder out for non-admin pages, gate the LV call site on `Scope.admin?/1` — the context API itself is not auth-gated.
+
+```elixir
+# Reorder entity definitions
+:ok = PhoenixKitEntities.reorder_entities([uuid_b, uuid_a, uuid_c], actor_uuid: admin.uuid)
+
+# Reorder data records within one entity
+:ok = PhoenixKitEntities.EntityData.reorder(entity.uuid, [r3.uuid, r1.uuid, r2.uuid], actor_uuid: admin.uuid)
 ```
 
 ## Field types

--- a/dev_docs/pull_requests/2026/10-test-migrations-mount-followups/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/10-test-migrations-mount-followups/FOLLOW_UP.md
@@ -1,0 +1,109 @@
+# Follow-up Items for PR #10 (Drop hand-rolled test migrations + close mount/3 review follow-ups)
+
+PR #10 was a follow-up to PR #9 — Batch 6 (test migration cleanup,
+−521 lines DDL, +5 lines fixture corrections) and Batch 7 (mount/3 →
+handle_params/3 in `data_form.ex` / `entity_form.ex` /
+`entities_settings.ex`). Merged 2026-04-29.
+
+The reviewer's six findings + four "Suggested follow-ups" are
+triaged below against current code (HEAD = `2fbeaa2`).
+
+## Fixed (pre-existing)
+
+- ~~**§1 `{:ok, socket}` wrapper on hydrate helpers**~~ —
+  `lib/phoenix_kit_entities/web/data_form.ex:85` (`hydrate_data_form/6`)
+  and `web/entity_form.ex:55` (`hydrate_entity_form/4`) now return
+  socket directly; callers in `handle_params/3` wrap with
+  `{:noreply, hydrate_*(...)}`. The vestigial `{:ok, _}` shape the
+  reviewer flagged is gone.
+- ~~**§3 "load admin dashboard" comment**~~ —
+  `lib/phoenix_kit_entities/web/entities_settings.ex:47-49` already
+  carries the warning the reviewer suggested verbatim:
+  > Canonical "load admin dashboard" path. Runs once on initial
+  > connected mount; would also re-run on any future `push_patch/2`
+  > to this LV. Keep cheap-looking work out of here — every read
+  > below multiplies on patch.
+- ~~**Suggested follow-up #3 — "no module-owned DDL" rule in
+  AGENTS.md**~~ — `AGENTS.md:429` documents the rule
+  ("`test_helper.exs` runs `Ecto.Migrator.run/4` against
+  `PhoenixKit.Migration` — no module-owned test DDL"); `AGENTS.md:169`
+  cross-references core's V17/V40/V58/V67/V74/V81 as the owners of
+  the entities tables.
+
+## Fixed (Batch 1 — 2026-05-02) (commit `2fbeaa2`)
+
+- ~~**§5 placeholder bcrypt hash in user-seed fixtures**~~ —
+  Added `PhoenixKitEntities.DataCase.valid_test_password_hash/0`
+  computed once at compile time via
+  `@valid_test_password_hash Bcrypt.hash_pwd_salt("test")`. Returns a
+  real bcrypt hash whose plaintext is `"test"`, suitable for
+  `phoenix_kit_users.hashed_password` seeds. Both call sites updated:
+  - `test/phoenix_kit_entities/mirror/importer_test.exs:35`
+  - `test/phoenix_kit_entities/mix_tasks/import_test.exs:37`
+
+  The previous `"$2b$12$placeholder"` literal was a syntactically
+  valid bcrypt prefix but a malformed payload —
+  `Bcrypt.verify_pass/2` against it would crash rather than return
+  `false`. Today's tests don't authenticate, but the foot-gun is
+  removed for any future caller.
+
+## Skipped (with rationale)
+
+- **§2 hydrate re-runs on every patch** — Reviewer marked this
+  "Latent / not currently triggering" and explicitly bounded scope
+  with "**No change requested in this PR** — flagging for the next
+  person who touches the LV." Verified neither LV patches itself
+  (`grep -rn "live_patch\|push_patch" lib/phoenix_kit_entities/web/`
+  returns only `entities.ex:54` and `data_navigator.ex`, both
+  cross-LV navigations). `Phoenix.PubSub.subscribe/2` is idempotent
+  per-process, so even if patching is added later the duplicate
+  subscribe is a no-op rather than a duplicate-message bug. A
+  defensive "have we hydrated for this URI?" guard would be
+  speculative — adding code we can't currently exercise.
+- **§4 / Suggested follow-up #1 — CHANGELOG + version bump for
+  `PhoenixKitEntities.Migrations.V1` removal** — Releases (version
+  bumps, CHANGELOG entries) are owned by the project maintainer per
+  the workspace memory rule, not auto-applied by the sweep
+  pipeline. Current version is `0.1.6`; a `0.2.0` bump for the
+  breaking public-module deletion is appropriate at the next
+  release cut. Surfaced for Max.
+- **Suggested follow-up #2 — Drop `{:ok, socket}` wrapper** —
+  superseded by "Fixed (pre-existing)" above.
+- **Suggested follow-up #4 — `valid_test_password_hash/0`
+  helper** — superseded by "Fixed (Batch 1)" above.
+
+## Note
+
+- **§6 `account_type = 'person'`** — confirmation-only finding; the
+  fixture migration from `'personal'` (hand-rolled test schema) to
+  `'person'` (production CHECK constraint) is the textbook example of
+  the drift bug the test-migration cleanup was designed to surface.
+  Already captured in PR #10's body and the workspace
+  `migration_cleanup.md` doc.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `test/support/data_case.ex` | Added `valid_test_password_hash/0` helper backed by a compile-time `Bcrypt.hash_pwd_salt/1` module attribute |
+| `test/phoenix_kit_entities/mirror/importer_test.exs` | Replaced `"$2b$12$placeholder"` literal with `valid_test_password_hash()` call |
+| `test/phoenix_kit_entities/mix_tasks/import_test.exs` | Same replacement as above |
+
+## Verification
+
+- `mix compile` passes for the test-support compilation; the only
+  warnings are the documented standalone-vs-parent gap (the local
+  module schema references `:position` on `phoenix_kit_entities`,
+  added by a not-yet-published V108 in core; canonical channel is
+  via `phoenix_kit_parent` per `feedback_run_tests_via_parent.md`).
+- `valid_test_password_hash/0` is reachable from both fixtures via
+  `use PhoenixKitEntities.DataCase` (the `using` block already
+  imports the case module).
+- The fixture inserts that previously stored `"$2b$12$placeholder"`
+  now persist a verifiable bcrypt hash — a future test can call
+  `Bcrypt.verify_pass("test", row.hashed_password)` and get `true`
+  back.
+
+## Open
+
+None.

--- a/lib/phoenix_kit_entities.ex
+++ b/lib/phoenix_kit_entities.ex
@@ -710,33 +710,80 @@ defmodule PhoenixKitEntities do
   Wraps both passes in a single transaction. Returns `:ok` on success
   or `{:error, reason}` on transaction failure.
   """
-  @spec reorder_entities([Ecto.UUID.t()]) :: :ok | {:error, term()}
-  def reorder_entities(ordered_uuids) when is_list(ordered_uuids) do
-    pairs = Enum.with_index(ordered_uuids, 1)
+  # Same cap as `EntityData.bulk_update_positions/2`. Reorder is a
+  # per-page action; even a workspace with hundreds of entities would
+  # never paint a thousand at once.
+  @reorder_entities_max_uuids 1000
 
-    case repo().transaction(fn ->
-           Enum.each(pairs, fn {uuid, idx} ->
-             from(e in __MODULE__, where: e.uuid == ^uuid)
-             |> repo().update_all(set: [position: idx, date_updated: UtilsDate.utc_now()])
-           end)
-         end) do
+  @spec reorder_entities([Ecto.UUID.t()], keyword()) :: :ok | {:error, term()}
+  def reorder_entities(ordered_uuids, opts \\ [])
+
+  def reorder_entities(ordered_uuids, _opts)
+      when is_list(ordered_uuids) and length(ordered_uuids) > @reorder_entities_max_uuids do
+    {:error, :too_many_uuids}
+  end
+
+  def reorder_entities(ordered_uuids, opts) when is_list(ordered_uuids) do
+    # Dedup defensively (last occurrence wins, same shape as
+    # `EntityData.bulk_update_positions/2`).
+    unique_uuids =
+      ordered_uuids
+      |> Enum.reverse()
+      |> Enum.uniq()
+      |> Enum.reverse()
+
+    case write_entity_positions(unique_uuids) do
       {:ok, _} ->
+        # Audit-log the reorder. Metadata stays PII-safe — count + the
+        # first uuid are enough to attribute the action and locate it
+        # in the table; the full ordered list would bloat the row and
+        # add no diagnostic value beyond what `Entities.list_entities/0`
+        # at the same instant already shows.
+        log_entity_reorder_activity(unique_uuids, opts)
+
         # Reuse the existing `:entity_updated` event — it's already
         # wired to invalidate the Dashboard sidebar cache and refresh
         # any open Entities/EntitiesSettings/DataNavigator LVs that
         # render entity-keyed lists. Broadcasting once with the first
         # uuid is sufficient since every listener re-fetches the full
         # list on receipt.
-        case List.first(ordered_uuids) do
-          uuid when is_binary(uuid) -> Events.broadcast_entity_updated(uuid)
-          _ -> :ok
-        end
+        broadcast_first_entity_updated(unique_uuids)
 
         :ok
 
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp write_entity_positions(unique_uuids) do
+    pairs = Enum.with_index(unique_uuids, 1)
+    now = UtilsDate.utc_now()
+
+    repo().transaction(fn ->
+      Enum.each(pairs, fn {uuid, idx} ->
+        from(e in __MODULE__, where: e.uuid == ^uuid)
+        |> repo().update_all(set: [position: idx, date_updated: now])
+      end)
+    end)
+  end
+
+  defp broadcast_first_entity_updated([uuid | _]) when is_binary(uuid),
+    do: Events.broadcast_entity_updated(uuid)
+
+  defp broadcast_first_entity_updated(_), do: :ok
+
+  defp log_entity_reorder_activity([], _opts), do: :ok
+
+  defp log_entity_reorder_activity([first_uuid | _rest] = uuids, opts) do
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: "entity.reordered",
+      mode: "manual",
+      actor_uuid: Keyword.get(opts, :actor_uuid),
+      resource_type: "entity",
+      resource_uuid: first_uuid,
+      metadata: %{"count" => length(uuids)}
+    })
   end
 
   @doc """

--- a/lib/phoenix_kit_entities.ex
+++ b/lib/phoenix_kit_entities.ex
@@ -118,6 +118,7 @@ defmodule PhoenixKitEntities do
              :status,
              :fields_definition,
              :settings,
+             :position,
              :date_created,
              :date_updated
            ]}
@@ -131,6 +132,7 @@ defmodule PhoenixKitEntities do
     field(:status, :string, default: "published")
     field(:fields_definition, {:array, :map})
     field(:settings, :map)
+    field(:position, :integer, default: 0)
     field(:created_by_uuid, UUIDv7)
     field(:date_created, :utc_datetime)
     field(:date_updated, :utc_datetime)
@@ -165,6 +167,7 @@ defmodule PhoenixKitEntities do
       :status,
       :fields_definition,
       :settings,
+      :position,
       :created_by_uuid,
       :date_created,
       :date_updated
@@ -378,7 +381,7 @@ defmodule PhoenixKitEntities do
   @spec list_entities(keyword()) :: [t()]
   def list_entities(opts \\ []) do
     __MODULE__
-    |> order_by([e], desc: e.date_created)
+    |> order_by([e], asc: e.position, desc: e.date_created)
     |> preload([:creator])
     |> repo().all()
     |> maybe_resolve_langs(opts)
@@ -395,7 +398,7 @@ defmodule PhoenixKitEntities do
   def list_active_entities(opts \\ []) do
     from(e in __MODULE__,
       where: e.status == "published",
-      order_by: [desc: e.date_created],
+      order_by: [asc: e.position, desc: e.date_created],
       preload: [:creator]
     )
     |> repo().all()
@@ -413,7 +416,7 @@ defmodule PhoenixKitEntities do
     summaries =
       from(e in __MODULE__,
         where: e.status == "published",
-        order_by: [desc: e.date_created],
+        order_by: [asc: e.position, desc: e.date_created],
         select: %{
           name: e.name,
           display_name: e.display_name,
@@ -586,12 +589,29 @@ defmodule PhoenixKitEntities do
   """
   @spec create_entity(map(), keyword()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
   def create_entity(attrs \\ %{}, opts \\ []) do
-    attrs = maybe_add_created_by(attrs)
+    attrs =
+      attrs
+      |> maybe_add_created_by()
+      |> maybe_add_entity_position()
 
     %__MODULE__{}
     |> changeset(attrs)
     |> repo().insert()
     |> notify_entity_event(:created, opts)
+  end
+
+  # Auto-assign a position when the caller hasn't specified one — places
+  # the new entity at the end of the manual-order list. Existing tests /
+  # callers that pass `:position` keep control.
+  defp maybe_add_entity_position(attrs) when is_map(attrs) do
+    has_position =
+      Map.has_key?(attrs, :position) or Map.has_key?(attrs, "position")
+
+    if has_position do
+      attrs
+    else
+      Map.put(attrs, :position, next_entity_position())
+    end
   end
 
   # Auto-fill created_by_uuid with first admin if not provided
@@ -657,6 +677,66 @@ defmodule PhoenixKitEntities do
   @spec change_entity(t(), map()) :: Ecto.Changeset.t()
   def change_entity(%__MODULE__{} = entity, attrs \\ %{}) do
     changeset(entity, attrs)
+  end
+
+  @doc """
+  Returns the next available `position` for a new entity — i.e. one
+  past the highest currently used. Falls back to `1` when the table is
+  empty.
+  """
+  @spec next_entity_position() :: integer()
+  def next_entity_position do
+    max =
+      __MODULE__
+      |> select([e], max(e.position))
+      |> repo().one()
+
+    case max do
+      nil -> 1
+      n when is_integer(n) -> n + 1
+    end
+  end
+
+  @doc """
+  Re-indexes the supplied list of entity UUIDs into positions `1..N`
+  in the order given.
+
+  This is the entry point for the drag-and-drop reorder event from the
+  Entities admin LV. UUIDs not in the list are left at their current
+  positions; missing UUIDs in the table are silently skipped (the LV
+  always sends the full visible list, so partial sends are a stale-DOM
+  artifact and not worth blowing up over).
+
+  Wraps both passes in a single transaction. Returns `:ok` on success
+  or `{:error, reason}` on transaction failure.
+  """
+  @spec reorder_entities([Ecto.UUID.t()]) :: :ok | {:error, term()}
+  def reorder_entities(ordered_uuids) when is_list(ordered_uuids) do
+    pairs = Enum.with_index(ordered_uuids, 1)
+
+    case repo().transaction(fn ->
+           Enum.each(pairs, fn {uuid, idx} ->
+             from(e in __MODULE__, where: e.uuid == ^uuid)
+             |> repo().update_all(set: [position: idx, date_updated: UtilsDate.utc_now()])
+           end)
+         end) do
+      {:ok, _} ->
+        # Reuse the existing `:entity_updated` event — it's already
+        # wired to invalidate the Dashboard sidebar cache and refresh
+        # any open Entities/EntitiesSettings/DataNavigator LVs that
+        # render entity-keyed lists. Broadcasting once with the first
+        # uuid is sufficient since every listener re-fetches the full
+        # list on receipt.
+        case List.first(ordered_uuids) do
+          uuid when is_binary(uuid) -> Events.broadcast_entity_updated(uuid)
+          _ -> :ok
+        end
+
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   @doc """

--- a/lib/phoenix_kit_entities.ex
+++ b/lib/phoenix_kit_entities.ex
@@ -718,8 +718,9 @@ defmodule PhoenixKitEntities do
   @spec reorder_entities([Ecto.UUID.t()], keyword()) :: :ok | {:error, term()}
   def reorder_entities(ordered_uuids, opts \\ [])
 
-  def reorder_entities(ordered_uuids, _opts)
+  def reorder_entities(ordered_uuids, opts)
       when is_list(ordered_uuids) and length(ordered_uuids) > @reorder_entities_max_uuids do
+    log_entity_reorder_rejected(:too_many_uuids, length(ordered_uuids), opts)
     {:error, :too_many_uuids}
   end
 
@@ -752,6 +753,11 @@ defmodule PhoenixKitEntities do
         :ok
 
       {:error, reason} ->
+        # Cover the user-initiated action even when the DB write fails.
+        # `db_pending: true` lets log consumers distinguish from
+        # successful rows; the actor still gets attribution in the
+        # audit trail.
+        log_entity_reorder_activity_error(unique_uuids, reason, opts)
         {:error, reason}
     end
   end
@@ -783,6 +789,33 @@ defmodule PhoenixKitEntities do
       resource_type: "entity",
       resource_uuid: first_uuid,
       metadata: %{"count" => length(uuids)}
+    })
+  end
+
+  defp log_entity_reorder_activity_error([], _reason, _opts), do: :ok
+
+  defp log_entity_reorder_activity_error([first_uuid | _rest] = uuids, _reason, opts) do
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: "entity.reordered",
+      mode: "manual",
+      actor_uuid: Keyword.get(opts, :actor_uuid),
+      resource_type: "entity",
+      resource_uuid: first_uuid,
+      metadata: %{"count" => length(uuids), "db_pending" => true}
+    })
+  end
+
+  defp log_entity_reorder_rejected(reason, count, opts) do
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: "entity.reordered",
+      mode: "manual",
+      actor_uuid: Keyword.get(opts, :actor_uuid),
+      resource_type: "entity",
+      metadata: %{
+        "count" => count,
+        "db_pending" => true,
+        "rejected" => to_string(reason)
+      }
     })
   end
 

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -457,6 +457,16 @@ defmodule PhoenixKitEntities.EntityData do
   end
 
   # Broadcast a reorder event for an entity so live views refresh.
+  # Builds the WHERE clause for `bulk_update_positions/2`. When a
+  # scope uuid is supplied, the entity_uuid filter prevents a stray
+  # cross-entity uuid in the input list from rewriting positions in
+  # the wrong scope.
+  defp position_update_query(uuid, nil),
+    do: from(d in __MODULE__, where: d.uuid == ^uuid)
+
+  defp position_update_query(uuid, scope) when is_binary(scope),
+    do: from(d in __MODULE__, where: d.uuid == ^uuid and d.entity_uuid == ^scope)
+
   defp notify_reorder_event(entity_uuid) when is_binary(entity_uuid) do
     Events.broadcast_data_reordered(entity_uuid)
   end
@@ -751,25 +761,64 @@ defmodule PhoenixKitEntities.EntityData do
     __MODULE__.update(entity_data, %{position: position})
   end
 
+  # Cap on the number of UUIDs accepted by a single reorder/bulk
+  # call. Reorder is a per-page operation; even the largest realistic
+  # entity won't have 1000 records visible at once. Beyond this we'd
+  # expect an explicit batched API instead of an unbounded transaction.
+  @reorder_max_uuids 1000
+
   @doc """
   Bulk updates positions for multiple records.
 
   Accepts a list of `{uuid, position}` tuples. Each record is updated
   individually to trigger events and maintain consistency.
 
+  ## Options
+
+    * `:entity_uuid` — when provided, the WHERE clause also filters on
+      `entity_uuid`, so a stray UUID from another entity in the input
+      list cannot have its position rewritten by the wrong scope. The
+      LV reorder paths always pass this; programmatic callers should
+      too unless they really intend cross-entity rewrites.
+
+  Returns `{:error, :too_many_uuids}` if more than `#{1000}` pairs are
+  supplied — the cap protects the transaction from N+1 unbounded
+  `update_all` work and from a malformed LV payload turning into a
+  long-running write storm.
+
   ## Examples
 
-      iex> bulk_update_positions([{"uuid1", 1}, {"uuid2", 2}, {"uuid3", 3}])
+      iex> bulk_update_positions([{"uuid1", 1}, {"uuid2", 2}, {"uuid3", 3}], entity_uuid: e_uuid)
       :ok
   """
   def bulk_update_positions(uuid_position_pairs, opts \\ [])
+
+  def bulk_update_positions(uuid_position_pairs, _opts)
+      when is_list(uuid_position_pairs) and length(uuid_position_pairs) > @reorder_max_uuids do
+    {:error, :too_many_uuids}
+  end
+
+  def bulk_update_positions(uuid_position_pairs, opts)
       when is_list(uuid_position_pairs) do
+    entity_uuid_scope = Keyword.get(opts, :entity_uuid)
+
+    # Dedup defensively — a stale DOM may send the same UUID twice
+    # (e.g. a quick double-drop). We keep the *last* occurrence so the
+    # most recent intended position wins; same outcome the DB would
+    # produce, just without the wasted writes.
+    pairs =
+      uuid_position_pairs
+      |> Enum.reverse()
+      |> Enum.uniq_by(fn {uuid, _} -> uuid end)
+      |> Enum.reverse()
+
     result =
       repo().transaction(fn ->
         now = UtilsDate.utc_now()
 
-        Enum.each(uuid_position_pairs, fn {uuid, position} ->
-          from(d in __MODULE__, where: d.uuid == ^uuid)
+        Enum.each(pairs, fn {uuid, position} ->
+          uuid
+          |> position_update_query(entity_uuid_scope)
           |> repo().update_all(set: [position: position, date_updated: now])
         end)
       end)
@@ -777,7 +826,7 @@ defmodule PhoenixKitEntities.EntityData do
     case result do
       {:ok, _} ->
         entity_uuid =
-          Keyword.get(opts, :entity_uuid) || resolve_entity_uuid_from_pairs(uuid_position_pairs)
+          entity_uuid_scope || resolve_entity_uuid_from_pairs(uuid_position_pairs)
 
         notify_reorder_event(entity_uuid)
         :ok

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -467,6 +467,46 @@ defmodule PhoenixKitEntities.EntityData do
   defp position_update_query(uuid, scope) when is_binary(scope),
     do: from(d in __MODULE__, where: d.uuid == ^uuid and d.entity_uuid == ^scope)
 
+  # Audit-log a reorder failure so the user-initiated action is
+  # represented in the activity table even when the DB write rolls
+  # back. `db_pending: true` lets consumers distinguish from
+  # successful rows.
+  defp log_data_reorder_error(uuid_position_pairs, entity_uuid_scope, _reason, opts) do
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: "entity_data.reordered",
+      mode: "manual",
+      actor_uuid: Keyword.get(opts, :actor_uuid),
+      resource_type: "entity_data",
+      resource_uuid: first_uuid_from_pairs(uuid_position_pairs),
+      metadata: %{
+        "entity_uuid" => entity_uuid_scope,
+        "count" => length(uuid_position_pairs),
+        "db_pending" => true
+      }
+    })
+  end
+
+  # Audit-log an early-rejection (oversized payload). Same shape as
+  # the error path; flagged with `rejected:` so audit consumers can
+  # tell rejection apart from a DB failure.
+  defp log_data_reorder_rejected(reason, count, opts) do
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: "entity_data.reordered",
+      mode: "manual",
+      actor_uuid: Keyword.get(opts, :actor_uuid),
+      resource_type: "entity_data",
+      metadata: %{
+        "entity_uuid" => Keyword.get(opts, :entity_uuid),
+        "count" => count,
+        "db_pending" => true,
+        "rejected" => to_string(reason)
+      }
+    })
+  end
+
+  defp first_uuid_from_pairs([{uuid, _} | _]) when is_binary(uuid), do: uuid
+  defp first_uuid_from_pairs(_), do: nil
+
   defp notify_reorder_event(entity_uuid) when is_binary(entity_uuid) do
     Events.broadcast_data_reordered(entity_uuid)
   end
@@ -793,8 +833,9 @@ defmodule PhoenixKitEntities.EntityData do
   """
   def bulk_update_positions(uuid_position_pairs, opts \\ [])
 
-  def bulk_update_positions(uuid_position_pairs, _opts)
+  def bulk_update_positions(uuid_position_pairs, opts)
       when is_list(uuid_position_pairs) and length(uuid_position_pairs) > @reorder_max_uuids do
+    log_data_reorder_rejected(:too_many_uuids, length(uuid_position_pairs), opts)
     {:error, :too_many_uuids}
   end
 
@@ -832,6 +873,8 @@ defmodule PhoenixKitEntities.EntityData do
         :ok
 
       {:error, reason} ->
+        # Cover the user-initiated action even when the DB write fails.
+        log_data_reorder_error(uuid_position_pairs, entity_uuid_scope, reason, opts)
         {:error, reason}
     end
   end
@@ -927,14 +970,14 @@ defmodule PhoenixKitEntities.EntityData do
       iex> reorder(entity_uuid, ["uuid3", "uuid1", "uuid2"])
       :ok
   """
-  def reorder(entity_uuid, ordered_uuids)
+  def reorder(entity_uuid, ordered_uuids, opts \\ [])
       when is_binary(entity_uuid) and is_list(ordered_uuids) do
     pairs =
       ordered_uuids
       |> Enum.with_index(1)
       |> Enum.map(fn {uuid, pos} -> {uuid, pos} end)
 
-    bulk_update_positions(pairs, entity_uuid: entity_uuid)
+    bulk_update_positions(pairs, Keyword.put(opts, :entity_uuid, entity_uuid))
   end
 
   @doc """

--- a/lib/phoenix_kit_entities/web/data_form.ex
+++ b/lib/phoenix_kit_entities/web/data_form.ex
@@ -232,7 +232,10 @@ defmodule PhoenixKitEntities.Web.DataForm do
       require Logger
 
       Logger.error(
-        "Entity data validate failed: #{Exception.message(e)}\n#{Exception.format_stacktrace(__STACKTRACE__)}"
+        "Entity data validate failed: #{Exception.message(e)} " <>
+          "(entity_uuid=#{inspect(record_uuid_for_log(socket, :entity))} " <>
+          "data_record_uuid=#{inspect(record_uuid_for_log(socket, :data_record))})\n" <>
+          Exception.format_stacktrace(__STACKTRACE__)
       )
 
       {:noreply, put_flash(socket, :error, gettext("Validation error — your data is preserved."))}
@@ -249,10 +252,24 @@ defmodule PhoenixKitEntities.Web.DataForm do
       require Logger
 
       Logger.error(
-        "Entity data save failed: #{Exception.message(e)}\n#{Exception.format_stacktrace(__STACKTRACE__)}"
+        "Entity data save failed: #{Exception.message(e)} " <>
+          "(entity_uuid=#{inspect(record_uuid_for_log(socket, :entity))} " <>
+          "data_record_uuid=#{inspect(record_uuid_for_log(socket, :data_record))})\n" <>
+          Exception.format_stacktrace(__STACKTRACE__)
       )
 
       {:noreply, put_flash(socket, :error, gettext("Something went wrong. Please try again."))}
+  end
+
+  # Pulls the resource uuid off socket assigns for use in error log
+  # context. Returns `nil` when the assign is missing or the underlying
+  # struct hasn't been hydrated yet (e.g. an exception during the very
+  # first validate before the entity is loaded).
+  defp record_uuid_for_log(socket, key) do
+    case socket.assigns[key] do
+      %{uuid: uuid} -> uuid
+      _ -> nil
+    end
   end
 
   def handle_event("reset", _params, socket) do

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -332,42 +332,64 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
 
   def handle_event("reorder_records", %{"ordered_ids" => ordered_ids}, socket)
       when is_list(ordered_ids) do
-    if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
-      entity = socket.assigns.selected_entity
-      entity_uuid = socket.assigns.selected_entity_uuid
+    cond do
+      not Scope.admin?(socket.assigns.phoenix_kit_current_scope) ->
+        {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
 
-      cond do
-        is_nil(entity) or is_nil(entity_uuid) ->
-          {:noreply, socket}
+      is_nil(socket.assigns.selected_entity) or is_nil(socket.assigns.selected_entity_uuid) ->
+        {:noreply, socket}
 
-        true ->
-          # First drag implicitly switches the entity to manual sort —
-          # otherwise the visible order would snap back to date-created
-          # on the next refresh and the user would see their drag undone.
-          entity =
-            if Entities.manual_sort?(entity) do
-              entity
-            else
-              case Entities.update_sort_mode(entity, "manual") do
-                {:ok, updated} -> updated
-                _ -> entity
-              end
-            end
+      true ->
+        apply_record_reorder(socket, ordered_ids)
+    end
+  end
 
-          case EntityData.reorder(entity_uuid, ordered_ids) do
-            :ok ->
-              {:noreply,
-               socket
-               |> assign(:selected_entity, entity)
-               |> apply_filters()}
+  # Catch-all for malformed reorder_records payloads (missing
+  # ordered_ids key, wrong type). Defensive — the SortableGrid hook
+  # always produces a list under the right key, but a stale browser
+  # tab or a custom client could trip this. Flash + no-op rather than
+  # crash the LV socket.
+  def handle_event("reorder_records", _params, socket) do
+    {:noreply, put_flash(socket, :error, gettext("Failed to save the new order"))}
+  end
 
-            _ ->
-              {:noreply,
-               put_flash(socket, :error, gettext("Failed to save the new order"))}
-          end
-      end
+  defp apply_record_reorder(socket, ordered_ids) do
+    entity = ensure_manual_sort(socket.assigns.selected_entity)
+    entity_uuid = socket.assigns.selected_entity_uuid
+
+    case EntityData.reorder(entity_uuid, ordered_ids) do
+      :ok ->
+        {:noreply,
+         socket
+         |> assign(:selected_entity, entity)
+         |> apply_filters()}
+
+      _ ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to save the new order"))}
+    end
+  end
+
+  # First drag implicitly switches the entity to manual sort — otherwise
+  # the visible order would snap back to date-created on the next refresh
+  # and the user would see their drag undone. Logs a warning so admins
+  # can see the silent setting flip in the application log; the flip
+  # itself also lands as an `entity.updated` activity row via the
+  # context's notify hook.
+  defp ensure_manual_sort(entity) do
+    if Entities.manual_sort?(entity) do
+      entity
     else
-      {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+      case Entities.update_sort_mode(entity, "manual") do
+        {:ok, updated} ->
+          Logger.warning(
+            "DataNavigator: entity #{entity.uuid} (#{entity.name}) auto-switched sort_mode to \"manual\" on first drag"
+          )
+
+          updated
+
+        _ ->
+          entity
+      end
     end
   end
 

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -357,7 +357,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     entity = ensure_manual_sort(socket.assigns.selected_entity)
     entity_uuid = socket.assigns.selected_entity_uuid
 
-    case EntityData.reorder(entity_uuid, ordered_ids) do
+    case EntityData.reorder(entity_uuid, ordered_ids, actor_opts(socket)) do
       :ok ->
         {:noreply,
          socket

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -330,6 +330,47 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     end
   end
 
+  def handle_event("reorder_records", %{"ordered_ids" => ordered_ids}, socket)
+      when is_list(ordered_ids) do
+    if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
+      entity = socket.assigns.selected_entity
+      entity_uuid = socket.assigns.selected_entity_uuid
+
+      cond do
+        is_nil(entity) or is_nil(entity_uuid) ->
+          {:noreply, socket}
+
+        true ->
+          # First drag implicitly switches the entity to manual sort —
+          # otherwise the visible order would snap back to date-created
+          # on the next refresh and the user would see their drag undone.
+          entity =
+            if Entities.manual_sort?(entity) do
+              entity
+            else
+              case Entities.update_sort_mode(entity, "manual") do
+                {:ok, updated} -> updated
+                _ -> entity
+              end
+            end
+
+          case EntityData.reorder(entity_uuid, ordered_ids) do
+            :ok ->
+              {:noreply,
+               socket
+               |> assign(:selected_entity, entity)
+               |> apply_filters()}
+
+            _ ->
+              {:noreply,
+               put_flash(socket, :error, gettext("Failed to save the new order"))}
+          end
+      end
+    else
+      {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+    end
+  end
+
   def handle_event("toggle_select", %{"uuid" => uuid}, socket) do
     selected = socket.assigns.selected_uuids
 
@@ -1113,6 +1154,10 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
             <.table_default variant="zebra" size="sm">
               <.table_default_header>
                 <.table_default_row>
+                  <.table_default_header_cell
+                    :if={@selected_entity && length(@entity_data_records) > 1}
+                    class="w-8"
+                  ></.table_default_header_cell>
                   <.table_default_header_cell class="w-12">
                     <%= if length(@entity_data_records) > 0 do %>
                       <input
@@ -1140,9 +1185,25 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                   <.table_default_header_cell>{gettext("Actions")}</.table_default_header_cell>
                 </.table_default_row>
               </.table_default_header>
-              <.table_default_body>
+              <tbody
+                id={if @selected_entity, do: "data-records-tbody"}
+                data-sortable="true"
+                data-sortable-event="reorder_records"
+                data-sortable-items=".sortable-item"
+                data-sortable-hide-source="false"
+                phx-hook={if @selected_entity, do: "SortableGrid"}
+              >
                 <%= for data_record <- @entity_data_records do %>
-                  <.table_default_row>
+                  <.table_default_row
+                    class={if @selected_entity, do: "sortable-item"}
+                    data-id={data_record.uuid}
+                  >
+                    <.table_default_cell
+                      :if={@selected_entity && length(@entity_data_records) > 1}
+                      class="cursor-grab active:cursor-grabbing text-base-content/40"
+                    >
+                      <.icon name="hero-bars-3" class="w-4 h-4" />
+                    </.table_default_cell>
                     <.table_default_cell>
                       <input
                         type="checkbox"
@@ -1246,15 +1307,31 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                     </.table_default_cell>
                   </.table_default_row>
                 <% end %>
-              </.table_default_body>
+              </tbody>
             </.table_default>
           <% else %>
             <%!-- Card View --%>
-            <div class="grid gap-6">
-              <%= for data_record <- @entity_data_records do %>
-                <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow">
+            <%= if @selected_entity do %>
+              <.draggable_list
+                id="data-records-cards"
+                items={@entity_data_records}
+                item_id={&(&1.uuid)}
+                on_reorder="reorder_records"
+                draggable={length(@entity_data_records) > 1}
+                layout={:list}
+                gap="gap-6"
+              >
+                <:item :let={data_record}>
+                  <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow">
                   <div class="card-body">
                     <div class="flex items-start gap-3 mb-4">
+                      <div
+                        :if={length(@entity_data_records) > 1}
+                        class="cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 mt-1"
+                        title={gettext("Drag to reorder")}
+                      >
+                        <.icon name="hero-bars-3" class="w-5 h-5" />
+                      </div>
                       <input
                         type="checkbox"
                         class="checkbox checkbox-md mt-1"
@@ -1391,8 +1468,136 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                     </div>
                   </div>
                 </div>
-              <% end %>
-            </div>
+              </:item>
+            </.draggable_list>
+            <% else %>
+              <div class="grid gap-6">
+                <%= for data_record <- @entity_data_records do %>
+                  <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow">
+                    <div class="card-body">
+                      <div class="flex items-start gap-3 mb-4">
+                        <input
+                          type="checkbox"
+                          class="checkbox checkbox-md mt-1"
+                          phx-click="toggle_select"
+                          phx-value-uuid={data_record.uuid}
+                          checked={MapSet.member?(@selected_uuids, data_record.uuid)}
+                        />
+                        <div class="flex-1">
+                          <div class="flex items-start justify-between mb-2">
+                            <.link
+                              navigate={
+                                PhoenixKit.Utils.Routes.path(
+                                  "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}"
+                                )
+                              }
+                              class="flex-1 hover:text-primary transition-colors cursor-pointer"
+                            >
+                              <div class="flex items-center mb-2">
+                                <h3 class="card-title text-lg mr-3">{data_record.title}</h3>
+                                <span class="badge badge-outline">
+                                  {get_entity_name(@entities, data_record.entity_uuid)}
+                                </span>
+                              </div>
+                              <%= if data_record.slug do %>
+                                <p class="text-sm text-base-content/60 mb-2">
+                                  <.icon name="hero-link" class="w-4 h-4 inline mr-1" />
+                                  {data_record.slug}
+                                </p>
+                              <% end %>
+                              <%= if data_record.data && map_size(data_record.data) > 0 do %>
+                                <p class="text-sm text-base-content/70 mb-3">
+                                  {format_data_preview(data_record.data)}
+                                </p>
+                              <% end %>
+                            </.link>
+                            <div class="flex flex-col items-end">
+                              <span class={"badge #{status_badge_class(data_record.status)} mb-2"}>
+                                <.icon name={status_icon(data_record.status)} class="w-3 h-3 mr-1" />
+                                {status_label(data_record.status)}
+                              </span>
+                              <button
+                                class="btn btn-ghost btn-xs"
+                                phx-click="toggle_status"
+                                phx-value-uuid={data_record.uuid}
+                                title={gettext("Cycle status")}
+                              >
+                                <.icon name="hero-arrow-path" class="w-3 h-3" />
+                              </button>
+                            </div>
+                          </div>
+                          <div class="flex flex-wrap items-center gap-4 text-xs text-base-content/50 mb-4">
+                            <%= if data_record.creator do %>
+                              <span>
+                                <.icon name="hero-user" class="w-3 h-3 inline mr-1" />
+                                {data_record.creator.email}
+                              </span>
+                            <% end %>
+                            <span>
+                              <.icon name="hero-calendar" class="w-3 h-3 inline mr-1" />
+                              {gettext("Created")} {PhoenixKit.Utils.Date.format_date_with_user_format(
+                                data_record.date_created
+                              )}
+                            </span>
+                            <%= if data_record.date_updated != data_record.date_created do %>
+                              <span>
+                                <.icon name="hero-clock" class="w-3 h-3 inline mr-1" />
+                                {gettext("Updated")} {PhoenixKit.Utils.Date.format_date_with_user_format(
+                                  data_record.date_updated
+                                )}
+                              </span>
+                            <% end %>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="card-actions justify-end">
+                        <.link
+                          navigate={
+                            PhoenixKit.Utils.Routes.path(
+                              "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}"
+                            )
+                          }
+                          class="btn btn-outline btn-sm"
+                        >
+                          <.icon name="hero-eye" class="w-4 h-4 mr-1" /> {gettext("View")}
+                        </.link>
+                        <.link
+                          navigate={
+                            PhoenixKit.Utils.Routes.path(
+                              "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}/edit"
+                            )
+                          }
+                          class="btn btn-primary btn-sm"
+                        >
+                          <.icon name="hero-pencil" class="w-4 h-4 mr-1" /> {gettext("Edit")}
+                        </.link>
+                        <%= if data_record.status == "archived" do %>
+                          <button
+                            class="btn btn-success btn-sm"
+                            phx-click="restore_data"
+                            phx-value-uuid={data_record.uuid}
+                            phx-disable-with={gettext("…")}
+                            title={gettext("Restore data record")}
+                          >
+                            <.icon name="hero-arrow-path" class="w-4 h-4" />
+                          </button>
+                        <% else %>
+                          <button
+                            class="btn btn-error btn-sm"
+                            phx-click="archive_data"
+                            phx-value-uuid={data_record.uuid}
+                            phx-disable-with={gettext("…")}
+                            title={gettext("Archive data record")}
+                          >
+                            <.icon name="hero-trash" class="w-4 h-4" />
+                          </button>
+                        <% end %>
+                      </div>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           <% end %>
         <% end %>
       </div>

--- a/lib/phoenix_kit_entities/web/entities.ex
+++ b/lib/phoenix_kit_entities/web/entities.ex
@@ -98,7 +98,7 @@ defmodule PhoenixKitEntities.Web.Entities do
 
   def handle_event("reorder_entities", %{"ordered_ids" => ordered_ids}, socket)
       when is_list(ordered_ids) do
-    case Entities.reorder_entities(ordered_ids) do
+    case Entities.reorder_entities(ordered_ids, actor_opts(socket)) do
       :ok ->
         {:noreply,
          assign(socket, :entities, Entities.list_entities(lang: socket.assigns[:current_locale]))}
@@ -106,6 +106,14 @@ defmodule PhoenixKitEntities.Web.Entities do
       {:error, _reason} ->
         {:noreply, put_flash(socket, :error, gettext("Failed to save the new order"))}
     end
+  end
+
+  # Defensive catch-all: a stale browser tab or a custom client could
+  # push a malformed `reorder_entities` payload (missing `ordered_ids`
+  # or wrong type). Flash + no-op rather than crash the LV socket
+  # with a MatchError.
+  def handle_event("reorder_entities", _params, socket) do
+    {:noreply, put_flash(socket, :error, gettext("Failed to save the new order"))}
   end
 
   ## Live updates

--- a/lib/phoenix_kit_entities/web/entities.ex
+++ b/lib/phoenix_kit_entities/web/entities.ex
@@ -96,6 +96,18 @@ defmodule PhoenixKitEntities.Web.Entities do
     end
   end
 
+  def handle_event("reorder_entities", %{"ordered_ids" => ordered_ids}, socket)
+      when is_list(ordered_ids) do
+    case Entities.reorder_entities(ordered_ids) do
+      :ok ->
+        {:noreply,
+         assign(socket, :entities, Entities.list_entities(lang: socket.assigns[:current_locale]))}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to save the new order"))}
+    end
+  end
+
   ## Live updates
 
   @impl true
@@ -213,6 +225,7 @@ defmodule PhoenixKitEntities.Web.Entities do
               <.table_default variant="zebra" size="sm">
                 <.table_default_header>
                   <.table_default_row>
+                    <.table_default_header_cell :if={length(@entities) > 1} class="w-8"></.table_default_header_cell>
                     <.table_default_header_cell>{gettext("Entity")}</.table_default_header_cell>
                     <.table_default_header_cell>{gettext("Status")}</.table_default_header_cell>
                     <.table_default_header_cell>{gettext("Fields")}</.table_default_header_cell>
@@ -220,9 +233,22 @@ defmodule PhoenixKitEntities.Web.Entities do
                     <.table_default_header_cell>{gettext("Actions")}</.table_default_header_cell>
                   </.table_default_row>
                 </.table_default_header>
-                <.table_default_body>
+                <tbody
+                  id="entities-table-body"
+                  data-sortable="true"
+                  data-sortable-event="reorder_entities"
+                  data-sortable-items=".sortable-item"
+                  data-sortable-hide-source="false"
+                  phx-hook="SortableGrid"
+                >
                   <%= for entity <- @entities do %>
-                    <.table_default_row>
+                    <.table_default_row class="sortable-item" data-id={entity.uuid}>
+                      <.table_default_cell
+                        :if={length(@entities) > 1}
+                        class="cursor-grab active:cursor-grabbing text-base-content/40"
+                      >
+                        <.icon name="hero-bars-3" class="w-4 h-4" />
+                      </.table_default_cell>
                       <.table_default_cell>
                         <.link
                           navigate={
@@ -324,16 +350,26 @@ defmodule PhoenixKitEntities.Web.Entities do
                       </.table_default_cell>
                     </.table_default_row>
                   <% end %>
-                </.table_default_body>
+                </tbody>
               </.table_default>
             </div>
           <% end %>
 
           <%!-- Card View: always shown on small screens, shown on md+ when card mode selected --%>
           <div class={if @view_mode == "table", do: "md:hidden", else: ""}>
-            <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              <%= for entity <- @entities do %>
-                <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow">
+            <.draggable_list
+              id="entities-cards"
+              items={@entities}
+              item_id={&(&1.uuid)}
+              on_reorder="reorder_entities"
+              draggable={length(@entities) > 1}
+              layout={:grid}
+              cols={1}
+              gap="gap-6"
+              class="md:grid-cols-2 lg:grid-cols-3"
+            >
+              <:item :let={entity}>
+                <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow h-full">
                   <div class="card-body">
                     <div class="flex items-start justify-between mb-4">
                       <.link
@@ -434,8 +470,8 @@ defmodule PhoenixKitEntities.Web.Entities do
                     </div>
                   </div>
                 </div>
-              <% end %>
-            </div>
+              </:item>
+            </.draggable_list>
           </div>
         <% end %>
       </div>

--- a/lib/phoenix_kit_entities/web/entity_form.ex
+++ b/lib/phoenix_kit_entities/web/entity_form.ex
@@ -1942,12 +1942,11 @@ defmodule PhoenixKitEntities.Web.EntityForm do
                       </option>
                     </select>
                   </label>
-                  <%!-- TODO: uncomment when table drag-and-drop is ready --%>
-                  <%!-- <.label class="label">
+                  <.label class="label">
                     <span class="label-text-alt">
                       {gettext("Manual mode enables drag-and-drop reordering of records")}
                     </span>
-                  </.label> --%>
+                  </.label>
                 </div>
               </div>
             </div>

--- a/lib/phoenix_kit_entities/web/entity_form.ex
+++ b/lib/phoenix_kit_entities/web/entity_form.ex
@@ -954,8 +954,24 @@ defmodule PhoenixKitEntities.Web.EntityForm do
     rescue
       e ->
         require Logger
-        Logger.error("Entity save failed: #{Exception.message(e)}")
+
+        Logger.error(
+          "Entity save failed: #{Exception.message(e)} " <>
+            "(entity_uuid=#{inspect(entity_uuid_for_log(socket))})"
+        )
+
         {:noreply, put_flash(socket, :error, gettext("Something went wrong. Please try again."))}
+    end
+  end
+
+  # Pulls the entity uuid off socket assigns for error-log context.
+  # Returns `nil` for the new-entity path (no uuid yet) so the log
+  # line still differentiates "save failed before insert" from "save
+  # failed updating <uuid>".
+  defp entity_uuid_for_log(socket) do
+    case socket.assigns[:entity] do
+      %{uuid: uuid} -> uuid
+      _ -> nil
     end
   end
 
@@ -1006,7 +1022,11 @@ defmodule PhoenixKitEntities.Web.EntityForm do
           {:noreply, socket}
         rescue
           e ->
-            Logger.error("Failed to apply remote entity form change: #{inspect(e)}")
+            Logger.error(
+              "Failed to apply remote entity form change: #{inspect(e)} " <>
+                "(entity_uuid=#{inspect(entity_uuid_for_log(socket))})"
+            )
+
             {:noreply, socket}
         end
     end

--- a/test/phoenix_kit_entities/context_extras_test.exs
+++ b/test/phoenix_kit_entities/context_extras_test.exs
@@ -290,4 +290,72 @@ defmodule PhoenixKitEntities.ContextExtrasTest do
       assert %Ecto.Changeset{} = Entities.change_entity(ctx.published, %{display_name: "X"})
     end
   end
+
+  describe "reorder_entities/2 (drag-and-drop reordering)" do
+    test "next_entity_position/0 starts at 1 on an empty table" do
+      # The setup block already inserted three entities. Subtract them
+      # by checking that next_position is past the highest currently
+      # used.
+      {:ok, latest} =
+        Entities.create_entity(
+          %{
+            name: "ctx_position_probe",
+            display_name: "Probe",
+            display_name_plural: "Probes",
+            fields_definition: [%{"type" => "text", "key" => "title", "label" => "Title"}],
+            created_by_uuid: Ecto.UUID.generate()
+          },
+          actor_uuid: Ecto.UUID.generate()
+        )
+
+      assert Entities.next_entity_position() == latest.position + 1
+    end
+
+    test "reorder_entities/2 assigns positions 1..N in the supplied order", ctx do
+      ordered = [ctx.draft.uuid, ctx.published.uuid]
+
+      assert :ok = Entities.reorder_entities(ordered, actor_uuid: Ecto.UUID.generate())
+
+      assert Entities.get_entity!(ctx.draft.uuid).position == 1
+      assert Entities.get_entity!(ctx.published.uuid).position == 2
+    end
+
+    test "reorder_entities/2 caps oversized payloads at 1000 uuids" do
+      oversized = List.duplicate("00000000-0000-0000-0000-000000000000", 1001)
+      assert {:error, :too_many_uuids} = Entities.reorder_entities(oversized)
+    end
+
+    test "reorder_entities/2 deduplicates input — last occurrence wins", ctx do
+      # Two slots in the input both name :published — the *second* slot
+      # (index 2) should win, so :published lands at position 2 and
+      # the duplicate at position 1 is collapsed away.
+      ordered = [ctx.published.uuid, ctx.draft.uuid, ctx.published.uuid]
+      assert :ok = Entities.reorder_entities(ordered)
+
+      assert Entities.get_entity!(ctx.draft.uuid).position == 1
+      assert Entities.get_entity!(ctx.published.uuid).position == 2
+    end
+
+    test "reorder_entities/2 logs entity.reordered with actor_uuid + count", ctx do
+      actor_uuid = Ecto.UUID.generate()
+      ordered = [ctx.published.uuid, ctx.draft.uuid]
+
+      assert :ok = Entities.reorder_entities(ordered, actor_uuid: actor_uuid)
+
+      assert_activity_logged("entity.reordered",
+        actor_uuid: actor_uuid,
+        resource_type: "entity",
+        resource_uuid: ctx.published.uuid,
+        metadata: %{"count" => 2}
+      )
+    end
+
+    test "reorder_entities/2 broadcasts :entity_updated for sidebar cache invalidation", ctx do
+      :ok = PhoenixKitEntities.Events.subscribe_to_entities()
+
+      assert :ok = Entities.reorder_entities([ctx.published.uuid, ctx.draft.uuid])
+
+      assert_receive {:entity_updated, _uuid}, 500
+    end
+  end
 end

--- a/test/phoenix_kit_entities/entity_data_extras_test.exs
+++ b/test/phoenix_kit_entities/entity_data_extras_test.exs
@@ -158,6 +158,59 @@ defmodule PhoenixKitEntities.EntityDataExtrasTest do
       assert EntityData.get(ctx.beta.uuid).position == 11
     end
 
+    test "bulk_update_positions/2 rejects payloads above the 1000-uuid cap" do
+      # Cheap synthetic — we never reach the DB because the guard
+      # short-circuits on length. Real UUID strings aren't required.
+      oversized = Enum.map(1..1001, fn idx -> {"00000000-0000-0000-0000-000000000000", idx} end)
+      assert {:error, :too_many_uuids} = EntityData.bulk_update_positions(oversized)
+    end
+
+    test "bulk_update_positions/2 enforces entity_uuid scope — cross-entity uuids ignored", ctx do
+      actor_uuid = Ecto.UUID.generate()
+
+      {:ok, other_entity} =
+        Entities.create_entity(
+          %{
+            name: "ed_extras_other",
+            display_name: "ED Other",
+            display_name_plural: "ED Others",
+            fields_definition: [%{"type" => "text", "key" => "title", "label" => "Title"}],
+            created_by_uuid: actor_uuid
+          },
+          actor_uuid: actor_uuid
+        )
+
+      {:ok, foreign} =
+        EntityData.create(
+          %{
+            entity_uuid: other_entity.uuid,
+            title: "Foreign",
+            slug: "foreign-row",
+            status: "published",
+            data: %{"title" => "Foreign"},
+            created_by_uuid: actor_uuid
+          },
+          actor_uuid: actor_uuid
+        )
+
+      original_position = foreign.position
+
+      # Mix the foreign uuid into a reorder scoped to ctx.entity. The
+      # foreign row must NOT have its position rewritten.
+      pairs = [{ctx.alpha.uuid, 1}, {foreign.uuid, 2}, {ctx.beta.uuid, 3}]
+      assert :ok = EntityData.bulk_update_positions(pairs, entity_uuid: ctx.entity.uuid)
+
+      assert EntityData.get(ctx.alpha.uuid).position == 1
+      assert EntityData.get(ctx.beta.uuid).position == 3
+      assert EntityData.get(foreign.uuid).position == original_position
+    end
+
+    test "bulk_update_positions/2 deduplicates — last occurrence wins", ctx do
+      pairs = [{ctx.alpha.uuid, 1}, {ctx.alpha.uuid, 99}]
+      assert :ok = EntityData.bulk_update_positions(pairs, entity_uuid: ctx.entity.uuid)
+      assert EntityData.get(ctx.alpha.uuid).position == 99
+    end
+
     test "move_to_position/2 with same position is a noop", ctx do
       {:ok, _} = EntityData.update_position(ctx.alpha, 5)
       reread = EntityData.get(ctx.alpha.uuid)
@@ -175,10 +228,12 @@ defmodule PhoenixKitEntities.EntityDataExtrasTest do
       assert EntityData.get(ctx.alpha.uuid).position == 3
     end
 
-    test "reorder/2 assigns 1, 2, 3 by ordered uuids", ctx do
+    test "reorder/2 assigns positions 1, 2, 3 by ordered uuids", ctx do
       ordered = [ctx.gamma.uuid, ctx.alpha.uuid, ctx.beta.uuid]
-      result = EntityData.reorder(ctx.entity.uuid, ordered)
-      assert result == :ok or result == :noop or match?({:error, _}, result)
+      assert :ok = EntityData.reorder(ctx.entity.uuid, ordered)
+      assert EntityData.get(ctx.gamma.uuid).position == 1
+      assert EntityData.get(ctx.alpha.uuid).position == 2
+      assert EntityData.get(ctx.beta.uuid).position == 3
     end
   end
 

--- a/test/phoenix_kit_entities/mirror/importer_test.exs
+++ b/test/phoenix_kit_entities/mirror/importer_test.exs
@@ -32,7 +32,7 @@ defmodule PhoenixKitEntities.Mirror.ImporterTest do
       Repo.query(
         "INSERT INTO phoenix_kit_users (uuid, email, hashed_password, is_active, account_type, inserted_at, updated_at) " <>
           "VALUES ($1::uuid, $2, $3, true, 'person', NOW(), NOW()) ON CONFLICT (uuid) DO NOTHING",
-        [Ecto.UUID.dump!(user_uuid), "importer-test@example.com", "$2b$12$placeholder"]
+        [Ecto.UUID.dump!(user_uuid), "importer-test@example.com", valid_test_password_hash()]
       )
 
     {:ok, user_uuid: user_uuid}

--- a/test/phoenix_kit_entities/mix_tasks/import_test.exs
+++ b/test/phoenix_kit_entities/mix_tasks/import_test.exs
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.PhoenixKitEntities.ImportTest do
       Repo.query(
         "INSERT INTO phoenix_kit_users (uuid, email, hashed_password, is_active, account_type, inserted_at, updated_at) " <>
           "VALUES ($1::uuid, $2, $3, true, 'person', NOW(), NOW()) ON CONFLICT (uuid) DO NOTHING",
-        [Ecto.UUID.dump!(user_uuid), "import-task-test@example.com", "$2b$12$placeholder"]
+        [Ecto.UUID.dump!(user_uuid), "import-task-test@example.com", valid_test_password_hash()]
       )
 
     # Pre-seed an entity-export file so the importer has something to read.

--- a/test/phoenix_kit_entities/web/data_navigator_live_test.exs
+++ b/test/phoenix_kit_entities/web/data_navigator_live_test.exs
@@ -377,6 +377,61 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
     end
   end
 
+  describe "reorder_records (drag-and-drop)" do
+    test "reorders records and refreshes the list",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
+
+      [r1, r2, r3] = ctx.records
+      ordered = [r3.uuid, r1.uuid, r2.uuid]
+
+      render_hook(view, "reorder_records", %{"ordered_ids" => ordered})
+
+      assert EntityData.get(r3.uuid).position == 1
+      assert EntityData.get(r1.uuid).position == 2
+      assert EntityData.get(r2.uuid).position == 3
+    end
+
+    test "first drag implicitly switches sort_mode to manual + logs warning",
+         %{conn: conn} = ctx do
+      # Entity starts with default sort_mode = "auto"
+      assert Entities.get_sort_mode(ctx.entity) == "auto"
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
+
+      previous = Logger.level()
+      Logger.configure(level: :warning)
+      on_exit(fn -> Logger.configure(level: previous) end)
+
+      [r1, r2, _r3] = ctx.records
+
+      log =
+        ExUnit.CaptureLog.capture_log([level: :warning], fn ->
+          render_hook(view, "reorder_records", %{"ordered_ids" => [r2.uuid, r1.uuid]})
+        end)
+
+      # The flip is persisted on the entity row.
+      reread = Entities.get_entity!(ctx.entity.uuid)
+      assert Entities.get_sort_mode(reread) == "manual"
+
+      assert log =~ "auto-switched sort_mode to \"manual\""
+    end
+
+    test "malformed payload (no ordered_ids) flashes error without crashing",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
+
+      render_hook(view, "reorder_records", %{"unexpected" => "shape"})
+
+      assert render(view) =~ "Failed to save the new order"
+      # LV still alive.
+      assert render(view) =~ "Record 1"
+    end
+  end
+
   defp navigator_url(entity, opts \\ []) do
     base = "/en/admin/entities/#{entity.name}/data"
 

--- a/test/phoenix_kit_entities/web/entities_live_test.exs
+++ b/test/phoenix_kit_entities/web/entities_live_test.exs
@@ -104,6 +104,39 @@ defmodule PhoenixKitEntities.Web.EntitiesLiveTest do
     end
   end
 
+  describe "reorder_entities (drag-and-drop)" do
+    test "valid ordered_ids re-indexes positions and pins the activity actor_uuid",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, "/en/admin/entities")
+
+      ordered = [ctx.archived.uuid, ctx.published.uuid]
+      render_hook(view, "reorder_entities", %{"ordered_ids" => ordered})
+
+      assert Entities.get_entity!(ctx.archived.uuid).position == 1
+      assert Entities.get_entity!(ctx.published.uuid).position == 2
+
+      assert_activity_logged("entity.reordered",
+        actor_uuid: ctx.actor_uuid,
+        resource_type: "entity",
+        resource_uuid: ctx.archived.uuid,
+        metadata_has: %{"count" => 2}
+      )
+    end
+
+    test "malformed payload (no ordered_ids key) flashes error without crashing",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, "/en/admin/entities")
+
+      render_hook(view, "reorder_entities", %{"unexpected" => "shape"})
+
+      assert render(view) =~ "Failed to save the new order"
+      # LV still alive — no MatchError crash.
+      assert render(view) =~ ctx.published.display_name
+    end
+  end
+
   describe "handle_info catch-all" do
     test "ignores unrelated messages without crashing",
          %{conn: conn} = ctx do

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -60,4 +60,24 @@ defmodule PhoenixKitEntities.DataCase do
       end)
     end)
   end
+
+  # Computed at compile time so the `bcrypt_elixir` cost is paid once
+  # per suite, not once per test. The salt+hash baked into the module
+  # is stable for the life of the compiled test_support beam.
+  @valid_test_password_hash Bcrypt.hash_pwd_salt("test")
+
+  @doc """
+  Returns a valid bcrypt hash for seeding `phoenix_kit_users.hashed_password`
+  in test fixtures.
+
+  Replaces the hand-typed `"$2b$12$placeholder"` strings, which are
+  syntactically valid bcrypt prefixes but malformed payloads —
+  `Bcrypt.verify_pass/2` against them crashes rather than returning
+  `false`. Tests that seed and never authenticate still gain by
+  removing the foot-gun for any future caller that does.
+
+  The verifiable plaintext is `"test"` for any test that needs it.
+  """
+  @spec valid_test_password_hash() :: String.t()
+  def valid_test_password_hash, do: @valid_test_password_hash
 end


### PR DESCRIPTION
## Summary

Adds drag-and-drop reordering to two surfaces in the entities admin
UI — the **entity definitions list** at `/admin/entities` and the
**entity records list** inside `/admin/entities/:slug/data` — then
runs the workspace quality-sweep playbook over the new code:
PR-followup triage, three C12 Explore agents, and a 13-category
C12.5 adversarial deep dive.

7 commits across three logical groups:

- **Feature work** — schema field + reorder API + DnD wiring
- **PR #10 review follow-up** — close one of the still-live items
  from `10-test-migrations-mount-followups/CLAUDE_REVIEW.md`, write
  the missing `FOLLOW_UP.md`
- **Quality sweep** — security/audit/credo cleanups, pinning tests,
  C12.5 deep-dive findings (audit-on-error gap, doc gaps,
  Logger.error grep-ability)

### Depends on a forthcoming core PR

The DnD work touches three core APIs that aren't yet in a published
\`phoenix_kit\` release:

1. **V108 migration** — adds the \`position integer DEFAULT 0\` column
   to \`phoenix_kit_entities\` (also to \`phoenix_kit_cat_catalogues\`
   and \`phoenix_kit_cat_items\` for catalogue's parallel work).
2. **\`<.draggable_list>\`** — gained an \`:draggable\` boolean attr
   so callers can disable DnD without duplicating card markup.
3. **\`SortableGrid\`** hook in \`phoenix_kit.js\` — gained
   cross-container drop detection + scope passing via
   \`data-sortable-scope-*\` attrs (used by the catalogue side; the
   entities side only needs the basic hook, which already shipped).

Until that core PR lands, \`cd phoenix_kit_entities && mix test\`
will fail with \`column phoenix_kit_entities.position does not
exist\`. Test verification was done via \`phoenix_kit_parent\` per
the workspace memory \`feedback_run_tests_via_parent.md\`.

### PR follow-up(s)

- **PR #10** — \`2fbeaa2\` "PR #10 review follow-up — replace bcrypt
  placeholder with helper" + \`2b6cb1a\` "Add FOLLOW_UP.md for PR
  #10". The missing \`FOLLOW_UP.md\` is now in
  \`dev_docs/pull_requests/2026/10-test-migrations-mount-followups/\`,
  triaging all six review findings (F1 fixed-pre-existing, F3 +
  suggested f/u #3 also fixed-pre-existing, F5 fixed in this batch
  via the new \`PhoenixKitEntities.DataCase.valid_test_password_hash/0\`
  helper, F2 + F4 surfaced + skipped with reviewer-quoted rationale,
  F6 confirmation-only).

### Quality sweep

The big work, broken into logical commit groups.

#### Feature

- **\`4853cc9\`** — Drag-and-drop reordering. Adds \`:position\` to
  the Entity schema (V108 column), \`Entities.next_entity_position/0\`,
  and \`Entities.reorder_entities/2\`. Wires \`<.draggable_list>\` +
  table-tbody \`SortableGrid\` hook on \`Web.Entities\` (definitions
  list) and \`Web.DataNavigator\` (records list). The DataNavigator
  auto-flips \`sort_mode\` to \`\"manual\"\` on the first drag so
  the visual order doesn't snap back on the next refresh; the flip
  is logged + audited via the existing \`update_entity\` activity
  hook. \`list_entities\` / \`list_active_entities\` /
  \`list_entity_summaries\` now \`order_by [asc: :position, desc:
  :date_created]\` so legacy rows (position 0) tiebreak on
  date_created — UI stays unchanged until somebody drags. After
  reorder, broadcasts \`:entity_updated\` so the Dashboard sidebar's
  entity-summaries cache invalidates immediately instead of waiting
  on the 30-second TTL.

#### Security + audit

- **\`9cde8ae\`** — closes the C12 first-pass findings:
  - **\`EntityData.bulk_update_positions/2\`** now AND-filters every
    per-uuid \`update_all\` on \`d.entity_uuid == ^scope\` when the
    scope opt is supplied. Closes the cross-entity write hole where
    a stale or hostile LV payload with UUIDs from another entity
    would have its positions rewritten by the wrong scope.
  - **1000-uuid cap** on both reorder entry points
    (\`Entities.reorder_entities/1,2\` and \`bulk_update_positions/2\`).
    Returns \`{:error, :too_many_uuids}\` for oversized payloads;
    protects the transaction from N+1 unbounded write storms.
  - **Dedup** on input lists (last-occurrence wins). A double-drop
    or stale DOM no longer issues redundant per-uuid writes.
  - **Audit log** for \`Entities.reorder_entities/2\` —
    \`entity.reordered\` action with PII-safe metadata
    (\`%{\"count\" => n}\` + \`resource_uuid\` set to the first
    uuid). Threads \`actor_uuid\` from the LV via the standard
    \`actor_opts/1\` helper.
  - **Defensive catch-all** \`handle_event(\"reorder_*\", _params,
    socket)\` clauses on both \`Web.Entities\` and
    \`Web.DataNavigator\` — malformed payloads flash an error rather
    than crashing the LV with a \`MatchError\`.
  - **\`Logger.warning\`** when DataNavigator silently auto-flips
    \`sort_mode\` to \`\"manual\"\` so ops can see the implicit
    setting mutation.
  - **Credo refactoring** — extracted \`apply_record_reorder/2\`,
    \`ensure_manual_sort/1\`, \`write_entity_positions/1\`,
    \`broadcast_first_entity_updated/1\`, and
    \`position_update_query/2\` helpers to clear the
    \`Function body too deep\` and \`Function too complex\` findings.
    \`mix credo --strict\` was 4 issues at C0; now 0.
  - **Removed stale TODO** in \`entity_form.ex\` and uncommented the
    \"Manual mode enables drag-and-drop reordering of records\" help
    text now that DnD is live.

#### Tests

- **\`5fb26be\`** — pinning tests for the DnD work, per the
  playbook's C11 delta-audit rule (every modified production file
  has a test that would fail on revert):
  - \`entity_data_extras_test.exs\` — tightened the \`reorder/2\`
    test from a loose three-way assertion to a hard \`positions ==
    [1, 2, 3]\` pin. Added \`:too_many_uuids\` cap test, the
    cross-entity-scope pin (a foreign uuid in the input list MUST
    keep its original position), and a dedup test.
  - \`context_extras_test.exs\` — new \`reorder_entities/2\`
    describe block with five tests covering position assignment,
    the 1000-uuid cap, dedup, the \`entity.reordered\` activity log
    row (pins \`actor_uuid\`, \`metadata.count\`, \`resource_uuid\`),
    and the \`:entity_updated\` PubSub broadcast that drives
    sidebar-cache invalidation.
  - \`entities_live_test.exs\` — \`reorder_entities\` LV event
    happy path + malformed-payload catch-all.
  - \`data_navigator_live_test.exs\` — \`reorder_records\` happy
    path, auto-flip-to-manual + \`Logger.warning\` capture,
    malformed-payload catch-all.

#### Documentation + audit-on-error (C12.5 deep dive)

- **\`252f1e7\`** — closes two of the five C12.5 deep-dive findings
  (the other three turned out moot or out of scope, see below):
  - **Audit-log error coverage** — the new reorder paths logged only
    on \`:ok\`. Now they log on every branch:
    \`reorder_entities/2\` adds \`log_entity_reorder_activity_error/3\`
    on \`{:error, reason}\` from the DB transaction and
    \`log_entity_reorder_rejected/3\` on the \`:too_many_uuids\`
    early reject. Both write \`metadata.db_pending: true\`; the
    rejected case also carries \`metadata.rejected:
    \"too_many_uuids\"\`. \`bulk_update_positions/2\` mirrors the
    shape with \`log_data_reorder_error/4\` and
    \`log_data_reorder_rejected/3\`. \`EntityData.reorder/3\` grew
    an \`opts \\\\ []\` arg so the LV's \`actor_uuid\` threads all
    the way through the audit chain.
  - **Documentation** — README's \"Manual ordering\" section was
    scoped to data records only. Rewrote to cover both reorder
    surfaces (entity definitions + data records), the 1000-uuid cap,
    the cross-entity-scope guard, the audit shape, and the
    auto-flip-to-manual-on-first-drag behavior. Added a parallel
    \"Drag-and-drop reorder API\" subsection to \`AGENTS.md\` so the
    agent-side public-surface inventory matches.

- **\`e0ed29a\`** — closes the deep-dive's category-#5 finding:
  Logger.error context for grep-ability. Four \`Logger.error\` call
  sites in \`data_form.ex\` and \`entity_form.ex\` previously logged
  the exception message but not the failing record's uuid. Two
  private helpers — \`record_uuid_for_log/2\` (data_form) and
  \`entity_uuid_for_log/1\` (entity_form) — pull the resource uuid
  off socket assigns and tolerate the new-record path (no uuid yet)
  by returning \`nil\`.

#### Deep-dive findings that were out of scope or moot

- **#11 (DB index)** — surfaced as \"no composite index on
  \`phoenix_kit_entity_data (entity_uuid, position)\` for the
  manual-sort query.\" False alarm — V81 already creates exactly
  that index (\`phoenix_kit_entity_data_entity_position_idx\`).
- **#11 (\`entities.position\` index)** — V108's deliberate omission
  is right for the small entities list (a few dozen rows).

## Verification

\`\`\`
mix format --check-formatted    # clean
mix credo --strict              # 1065 mods/funs, 0 issues (was 4 at C0)
\`\`\`

Test baseline at C0 was 684 tests / 332 pre-existing failures, all
\`column phoenix_kit_entities.position does not exist\` from the
local \`:position\` schema field referencing a column added by V108
in core. The new pinning tests sit on the same V108 dependency and
will pass once the core PR lands. Manual browser smoke check
performed against \`phoenix_kit_parent\` running V108 locally —
table and card views both drag, positions persist, sidebar
re-renders in new order, audit rows land with \`actor_uuid\`.

## Test plan

- [x] \`mix format --check-formatted\` clean
- [x] \`mix credo --strict\` clean (was 4 issues at C0)
- [x] PR #10 \`FOLLOW_UP.md\` present, every review finding
      classified
- [x] C12 three-agent triage run, all in-scope findings closed
- [x] C12.5 13-category deep dive, all in-scope findings closed
- [x] Delta-audit per C11: every modified production file has a
      pinning test
- [x] Manual browser smoke via \`phoenix_kit_parent\` (V108 applied
      locally)
- [ ] \`mix test\` clean — pending core PR with V108
- [ ] Browser baseline diff vs C0 screenshots — skipped (DnD adds
      visible drag handles + footer rows, all expected)

---

**Head-ref deviation:** The harness pattern-matches \`git push\`
target on \`main\` and refuses fork-to-fork pushes even on a personal
remote. PR opened from \`mdon:dnd-reorder\` instead of \`mdon:main\`
per the workspace memory C16 fallback. After upstream merge, fast-
forward fork's main + delete \`dnd-reorder\` cleans up.