### PR TITLE
Fix #12 — soft-delete for EntityData (trash/restore + friendly FK error)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,9 +264,16 @@ config :phoenix_kit_entities,
 ```
 
 `EntityData.count_external_references/1` resolves the entity name to
-matching callbacks and sums them. Informational only — the admin UI
-can surface "Used by N orders" before showing the Trash button, but
-soft-delete is safe regardless.
+matching callbacks and sums them. Multiple callbacks per entity name
+are fine — they all contribute (e.g. `orders` + `audit_log` both
+referencing the same `order_status` add together). Informational
+only, **NOT a delete-blocker** — soft-delete is safe regardless of
+the count.
+
+The 1-arity form preloads `:entity` per call. When rendering many
+records (admin trash bin, list views), prefer the 2-arity form
+`count_external_references(record, entity)` and load the entity
+once outside the loop to skip the N+1.
 
 **Admin UX (DataNavigator).** Bulk Delete now soft-trashes by default;
 permanent delete is a separate action available only from the Trash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,73 @@ V108 for entities) that drives manual sort.
 | `metadata.db_pending`  | absent                            | `true`                  | `true`                        |
 | `metadata.rejected`    | absent                            | absent                  | `"too_many_uuids"`            |
 
+### Soft-delete (trash) for EntityData
+
+EntityData records support soft-delete via the `status` column with the
+sentinel `"trashed"` (workspace convention — same as publishing posts).
+The row stays alive in the DB so parent-app FK references stay
+satisfied; default `list_*` queries hide trashed rows.
+
+**Why this matters.** Parent apps commonly use entity_data records as
+controlled vocabularies (e.g. `orders.status_uuid → phoenix_kit_entity_data(uuid)`,
+NOT NULL). Hard-deleting via `Repo.delete` triggers the parent's FK
+action — `:nilify_all` violates NOT NULL, `:restrict` blocks, `:delete_all`
+cascades — and the admin sees an opaque 500. Soft-delete sidesteps all
+three: the row survives, the parent's FK keeps resolving, and the
+admin can restore later or permanently delete once references clear.
+
+**Public API:**
+
+- `EntityData.trash/2` — flips status to `"trashed"`. Refuses
+  `{:error, :already_trashed}` for already-trashed rows. Logs
+  `entity_data.trashed`.
+- `EntityData.restore_from_trash/2` — flips trashed → published.
+  Refuses `{:error, :not_trashed}` for non-trashed rows. Logs
+  `entity_data.restored`.
+- `EntityData.bulk_trash/2` + `bulk_restore_from_trash/2` — batched
+  versions; emit ONE `entity_data.bulk_trashed` /
+  `entity_data.bulk_restored` audit row per call. Skip already-state
+  rows via the WHERE clause.
+- `EntityData.list_trashed_by_entity/2` + `trashed_count/1` — surface
+  trashed rows for the admin trash bin.
+- `EntityData.delete/2` + `bulk_delete/2` — hard-delete.
+  **Wrapped in a Postgrex / Ecto.ConstraintError rescue** that catches
+  FK / NOT NULL violations and returns
+  `{:error, :referenced_by_external}` so the admin LV can render a
+  friendly flash via `Errors.message(:referenced_by_external)` instead
+  of 500. Re-raises any other constraint error so real bugs surface.
+
+**Default-list filtering.** `list_all`, `list_by_entity`,
+`search_by_title`, `count_by_entity`, and `get_data_stats` exclude
+trashed by default; pass `include_trashed: true` to surface them
+(used by reverse-reference checks and the admin trash view).
+`get_by_slug/3` is intentionally NOT filtered — slug uniqueness must
+survive trashing so a restored row doesn't collide with a
+freshly-created replacement.
+
+**Reverse-reference hook.** Parent apps with FK columns to
+entity_data can declare count callbacks via `Application` config:
+
+```elixir
+config :phoenix_kit_entities,
+  reverse_references: [
+    {"order_status", &MyApp.Orders.count_orders_with_status/1},
+    {"sub_order_status", &MyApp.Orders.count_sub_orders_with_status/1}
+  ]
+```
+
+`EntityData.count_external_references/1` resolves the entity name to
+matching callbacks and sums them. Informational only — the admin UI
+can surface "Used by N orders" before showing the Trash button, but
+soft-delete is safe regardless.
+
+**Admin UX (DataNavigator).** Bulk Delete now soft-trashes by default;
+permanent delete is a separate action available only from the Trash
+filter view (`status=trashed` query param). Per-record buttons branch
+by status: published/draft → Archive + Trash, archived → Restore +
+Trash, trashed → Restore-from-trash + Delete-forever. The
+`toggle_status` cycle skips trashed (Restore is the only escape).
+
 ### Activity Logging Pattern
 
 Mutations log via `PhoenixKitEntities.ActivityLog.log/1`, which wraps
@@ -238,9 +305,12 @@ activity logging only fires on `:ok` and the `:error` tuple flows
 through unchanged.
 
 Action-atom convention: `"entity.{verb}"` and `"entity_data.{verb}"`
-where verb is one of `created`, `updated`, `deleted`,
-`bulk_status_changed`, `bulk_deleted`, `translation_set`. Module
-toggles use `"module.entities.{enabled|disabled}"`.
+where verb is one of `created`, `updated`, `deleted`, `trashed`,
+`restored`, `bulk_status_changed`, `bulk_deleted`, `bulk_trashed`,
+`bulk_restored`, `translation_set`. Module toggles use
+`"module.entities.{enabled|disabled}"`. Note `entity_data.deleted`
+fires for hard-delete; `entity_data.trashed` for soft-delete — keep
+them distinct so audit consumers can tell which path ran.
 
 PII guardrail at the source: never log `email`, `phone`, free-text
 `description` fields, raw `data` JSONB blobs, or any user-typed

--- a/lib/phoenix_kit_entities/controllers/entity_form_controller.ex
+++ b/lib/phoenix_kit_entities/controllers/entity_form_controller.ex
@@ -492,18 +492,18 @@ defmodule PhoenixKitEntities.Controllers.EntityFormController do
     Regex.match?(~r/^(?:\d{1,3}\.){3}\d{1,3}$/, ip) and not private_or_local_ip?(ip)
   end
 
+  # Integer.parse/1 returns `{int, rest}` or `:error` instead of raising,
+  # so we can drop the rescue clause and pin the failure shape explicitly.
+  # Any non-numeric octet (e.g. "abc.def.ghi.jkl" slipping past the regex,
+  # or values overflowing int) collapses to the safe-by-default `true`.
   defp private_or_local_ip?(ip) do
-    case String.split(ip, ".") do
-      [a, b, _, _] ->
-        a_int = String.to_integer(a)
-        b_int = String.to_integer(b)
-        unsafe_octets?(a_int, b_int)
-
-      _ ->
-        true
+    with [a, b, _, _] <- String.split(ip, "."),
+         {a_int, ""} <- Integer.parse(a),
+         {b_int, ""} <- Integer.parse(b) do
+      unsafe_octets?(a_int, b_int)
+    else
+      _ -> true
     end
-  rescue
-    _ -> true
   end
 
   # RFC1918 + loopback + link-local + multicast/reserved (224+).

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -11,7 +11,7 @@ defmodule PhoenixKitEntities.EntityData do
   - `entity_uuid`: Foreign key to the entity blueprint
   - `title`: Display title/name for the record
   - `slug`: URL-friendly identifier (optional)
-  - `status`: Record status ("draft", "published", "archived")
+  - `status`: Record status ("draft", "published", "archived", "trashed")
   - `data`: JSONB map of all field values based on entity definition
   - `metadata`: JSONB map for additional information (tags, categories, etc.)
   - `created_by`: User UUID who created the record
@@ -21,14 +21,17 @@ defmodule PhoenixKitEntities.EntityData do
   ## Core Functions
 
   ### Data Management
-  - `list_all/0` - Get all entity data records
-  - `list_by_entity/1` - Get all records for a specific entity
+  - `list_all/0` - Get all entity data records (excludes trashed by default)
+  - `list_by_entity/1` - Get all records for a specific entity (excludes trashed by default)
   - `list_by_entity_and_status/2` - Filter records by entity and status
+  - `list_trashed_by_entity/1` - Get only trashed records for an entity
   - `get!/1` - Get a record by ID (raises if not found)
-  - `get_by_slug/2` - Get a record by entity and slug
+  - `get_by_slug/2` - Get a record by entity and slug (returns trashed too — slug uniqueness)
   - `create/1` - Create a new record
   - `update/2` - Update an existing record
-  - `delete/1` - Delete a record
+  - `trash/1` - Soft-delete (sets status to "trashed", row stays alive — parent FKs keep resolving)
+  - `restore_from_trash/1` - Move a trashed record back to "published"
+  - `delete/1` - Hard-delete a record (returns `{:error, :referenced_by_external}` on FK violation)
   - `change/2` - Get changeset for forms
 
   ### Query Helpers
@@ -122,7 +125,8 @@ defmodule PhoenixKitEntities.EntityData do
     )
   end
 
-  @valid_statuses ~w(draft published archived)
+  @valid_statuses ~w(draft published archived trashed)
+  @soft_delete_status "trashed"
 
   @doc """
   Creates a changeset for entity data creation and updates.
@@ -415,6 +419,22 @@ defmodule PhoenixKitEntities.EntityData do
     {:ok, entity_data}
   end
 
+  defp notify_data_event({:ok, %__MODULE__{} = entity_data}, :trashed, opts) do
+    Events.broadcast_data_updated(entity_data.entity_uuid, entity_data.uuid)
+    # Re-export so the trashed record drops out of the mirror file
+    # (mirror queries default to non-trashed via list_data_by_entity).
+    maybe_mirror_data(entity_data)
+    log_data_activity(entity_data, "entity_data.trashed", opts)
+    {:ok, entity_data}
+  end
+
+  defp notify_data_event({:ok, %__MODULE__{} = entity_data}, :restored, opts) do
+    Events.broadcast_data_updated(entity_data.entity_uuid, entity_data.uuid)
+    maybe_mirror_data(entity_data)
+    log_data_activity(entity_data, "entity_data.restored", opts)
+    {:ok, entity_data}
+  end
+
   defp notify_data_event({:error, _} = result, event, opts) do
     log_data_error_activity(event, opts)
     result
@@ -556,6 +576,9 @@ defmodule PhoenixKitEntities.EntityData do
   @doc """
   Returns all entity data records ordered by creation date.
 
+  Trashed records are excluded by default. Pass `include_trashed: true` to
+  return them too — used by admin trash views and reverse-reference checks.
+
   ## Examples
 
       iex> PhoenixKitEntities.EntityData.list_all()
@@ -566,12 +589,16 @@ defmodule PhoenixKitEntities.EntityData do
       order_by: [desc: d.date_created],
       preload: [:entity, :creator]
     )
+    |> exclude_trashed(opts)
     |> repo().all()
     |> maybe_resolve_langs(opts)
   end
 
   @doc """
   Returns all entity data records for a specific entity.
+
+  Trashed records are excluded by default. Pass `include_trashed: true` to
+  return them too.
 
   ## Examples
 
@@ -586,8 +613,40 @@ defmodule PhoenixKitEntities.EntityData do
       order_by: ^order,
       preload: [:entity, :creator]
     )
+    |> exclude_trashed(opts)
     |> repo().all()
     |> maybe_resolve_langs(opts)
+  end
+
+  @doc """
+  Returns trashed records for a specific entity, ordered by most recently
+  updated (the default trash-bin view).
+
+  ## Examples
+
+      iex> PhoenixKitEntities.EntityData.list_trashed_by_entity(entity_uuid)
+      [%PhoenixKitEntities.EntityData{status: "trashed"}, ...]
+  """
+  def list_trashed_by_entity(entity_uuid, opts \\ []) when is_binary(entity_uuid) do
+    from(d in __MODULE__,
+      where: d.entity_uuid == ^entity_uuid and d.status == ^@soft_delete_status,
+      order_by: [desc: d.date_updated],
+      preload: [:entity, :creator]
+    )
+    |> repo().all()
+    |> maybe_resolve_langs(opts)
+  end
+
+  # Appends `where: status != "trashed"` unless caller opted in via
+  # `include_trashed: true`. Public consumers (sitemap, mirror exporter,
+  # admin default views) get the safe-by-default exclusion; trash-tab
+  # views and reverse-reference checks pass `include_trashed: true`.
+  defp exclude_trashed(query, opts) do
+    if Keyword.get(opts, :include_trashed, false) do
+      query
+    else
+      from(d in query, where: d.status != ^@soft_delete_status)
+    end
   end
 
   @doc """
@@ -1007,21 +1066,118 @@ defmodule PhoenixKitEntities.EntityData do
   end
 
   @doc """
-  Deletes an entity data record.
+  Hard-deletes an entity data record.
+
+  Prefer `trash/2` for soft-delete — it keeps the row alive so parent-app
+  FK references stay valid. Use this only when the record is genuinely
+  unreferenced (e.g. emptying the trash bin).
+
+  Catches `Postgrex.Error` for FK / NOT NULL violations and returns
+  `{:error, :referenced_by_external}` so the admin UI can render a friendly
+  flash instead of a 500. The row stays in the DB on this error.
 
   ## Examples
 
       iex> PhoenixKitEntities.EntityData.delete(record)
       {:ok, %PhoenixKitEntities.EntityData{}}
 
+      iex> # parent_app.orders has a NOT NULL FK to this row
       iex> PhoenixKitEntities.EntityData.delete(record)
-      {:error, %Ecto.Changeset{}}
+      {:error, :referenced_by_external}
   """
-  @spec delete(t(), keyword()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  @spec delete(t(), keyword()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t() | :referenced_by_external}
   def delete(%__MODULE__{} = entity_data, opts \\ []) do
     repo().delete(entity_data)
     |> notify_data_event(:deleted, opts)
+  rescue
+    # Ecto wraps Postgrex FK violations on Repo.delete in
+    # `Ecto.ConstraintError` because `delete/1` doesn't go through a
+    # changeset with declared constraints.
+    e in Ecto.ConstraintError ->
+      if e.type == :foreign_key do
+        log_data_error_activity(:deleted, opts)
+        {:error, :referenced_by_external}
+      else
+        reraise e, __STACKTRACE__
+      end
+
+    e in Postgrex.Error ->
+      if foreign_key_or_not_null_violation?(e) do
+        log_data_error_activity(:deleted, opts)
+        {:error, :referenced_by_external}
+      else
+        reraise e, __STACKTRACE__
+      end
   end
+
+  @doc """
+  Soft-deletes an entity data record by setting its status to `"trashed"`.
+
+  The row remains in the database so any parent-app FK references stay
+  valid — historical orders, audit logs, etc. continue to resolve. The
+  record is hidden from default `list_*` queries; use `list_trashed_by_entity/2`
+  to surface it for the admin trash view.
+
+  Logs `entity_data.trashed` activity. Refuses with `{:error, :already_trashed}`
+  if the record is already trashed.
+
+  ## Examples
+
+      iex> EntityData.trash(record, actor_uuid: admin.uuid)
+      {:ok, %EntityData{status: "trashed"}}
+  """
+  @spec trash(t(), keyword()) :: {:ok, t()} | {:error, :already_trashed | Ecto.Changeset.t()}
+  def trash(%__MODULE__{status: @soft_delete_status}, _opts), do: {:error, :already_trashed}
+
+  def trash(%__MODULE__{} = entity_data, opts) when is_list(opts) do
+    entity_data
+    |> changeset(%{status: @soft_delete_status})
+    |> repo().update()
+    |> notify_data_event(:trashed, opts)
+  end
+
+  def trash(%__MODULE__{} = entity_data), do: trash(entity_data, [])
+
+  @doc """
+  Restores a trashed entity data record by setting its status back to
+  `"published"`.
+
+  Returns `{:error, :not_trashed}` if the record isn't currently trashed —
+  this is a guardrail against re-publishing arbitrary records via the
+  trash-restore path. Use `update/2` for general status changes.
+
+  ## Examples
+
+      iex> EntityData.restore_from_trash(trashed_record, actor_uuid: admin.uuid)
+      {:ok, %EntityData{status: "published"}}
+  """
+  @spec restore_from_trash(t(), keyword()) ::
+          {:ok, t()} | {:error, :not_trashed | Ecto.Changeset.t()}
+  def restore_from_trash(entity_data, opts \\ [])
+
+  def restore_from_trash(%__MODULE__{status: @soft_delete_status} = entity_data, opts) do
+    entity_data
+    |> changeset(%{status: "published"})
+    |> repo().update()
+    |> notify_data_event(:restored, opts)
+  end
+
+  def restore_from_trash(%__MODULE__{}, _opts), do: {:error, :not_trashed}
+
+  # Match Postgres FK / NOT NULL violations raised when a parent-app row
+  # still references this record. SQLSTATE codes are stable: `23503` =
+  # foreign_key_violation, `23502` = not_null_violation. Any other error
+  # is re-raised so real bugs still surface.
+  defp foreign_key_or_not_null_violation?(%Postgrex.Error{postgres: %{code: code}})
+       when code in [:foreign_key_violation, :not_null_violation],
+       do: true
+
+  defp foreign_key_or_not_null_violation?(%Postgrex.Error{postgres: %{code: code}})
+       when is_binary(code) and code in ["23503", "23502"],
+       do: true
+
+  defp foreign_key_or_not_null_violation?(_), do: false
 
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking entity data changes.
@@ -1075,7 +1231,9 @@ defmodule PhoenixKitEntities.EntityData do
           from(d in query, where: d.entity_uuid == ^uuid)
       end
 
-    repo().all(query)
+    query
+    |> exclude_trashed(opts)
+    |> repo().all()
     |> maybe_resolve_langs(opts)
   end
 
@@ -1092,20 +1250,42 @@ defmodule PhoenixKitEntities.EntityData do
   end
 
   @doc """
-  Counts the total number of records for an entity.
+  Counts records for an entity.
+
+  Excludes trashed records by default. Pass `include_trashed: true` to
+  count everything.
 
   ## Examples
 
       iex> PhoenixKitEntities.EntityData.count_by_entity(entity_uuid)
       42
+
+      iex> PhoenixKitEntities.EntityData.count_by_entity(entity_uuid, include_trashed: true)
+      45
   """
-  def count_by_entity(entity_uuid) when is_binary(entity_uuid) do
+  def count_by_entity(entity_uuid, opts \\ []) when is_binary(entity_uuid) do
     from(d in __MODULE__, where: d.entity_uuid == ^entity_uuid, select: count(d.uuid))
+    |> exclude_trashed(opts)
+    |> repo().one()
+  end
+
+  @doc """
+  Counts trashed records for an entity. Drives the trash-bin badge.
+  """
+  def trashed_count(entity_uuid) when is_binary(entity_uuid) do
+    from(d in __MODULE__,
+      where: d.entity_uuid == ^entity_uuid and d.status == ^@soft_delete_status,
+      select: count(d.uuid)
+    )
     |> repo().one()
   end
 
   @doc """
   Gets records filtered by status across all entities.
+
+  When `status` is `"trashed"`, returns trashed records. For all other
+  statuses, the query is implicitly scoped (status filter excludes trashed
+  by virtue of matching a different status).
 
   ## Examples
 
@@ -1341,8 +1521,57 @@ defmodule PhoenixKitEntities.EntityData do
   @doc """
   Alias for delete/1 for consistency with LiveView naming.
   """
-  @spec delete_data(t(), keyword()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
+  @spec delete_data(t(), keyword()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t() | :referenced_by_external}
   def delete_data(entity_data, opts \\ []), do: __MODULE__.delete(entity_data, opts)
+
+  @doc """
+  Counts external (parent-app) rows that reference this record.
+
+  Reads `:reverse_references` from `Application.get_env/2` — a list of
+  `{entity_name, count_fn}` tuples where `count_fn` is a 1-arity
+  function that takes the entity_data uuid and returns a non-negative
+  integer. Returns the total count across all matching callbacks for
+  the record's entity, or `0` if no callbacks are registered.
+
+  This is informational, not a delete-blocker — soft-delete keeps the
+  row alive regardless. Used by the admin to render "Used by N rows"
+  hints before the operator clicks Trash or Permanently delete.
+
+  ## Configuration
+
+      # In parent app config:
+      config :phoenix_kit_entities,
+        reverse_references: [
+          {"order_status", &MyApp.Orders.count_orders_with_status/1},
+          {"sub_order_status", &MyApp.Orders.count_sub_orders_with_status/1}
+        ]
+  """
+  @spec count_external_references(t()) :: non_neg_integer()
+  def count_external_references(%__MODULE__{} = entity_data) do
+    entity = repo().preload(entity_data, :entity).entity
+
+    case entity do
+      %{name: name} when is_binary(name) ->
+        :phoenix_kit_entities
+        |> Application.get_env(:reverse_references, [])
+        |> Enum.filter(fn
+          {^name, fun} when is_function(fun, 1) -> true
+          _ -> false
+        end)
+        |> Enum.reduce(0, fn {_name, fun}, acc ->
+          try do
+            count = fun.(entity_data.uuid)
+            if is_integer(count) and count >= 0, do: acc + count, else: acc
+          rescue
+            _ -> acc
+          end
+        end)
+
+      _ ->
+        0
+    end
+  end
 
   @doc """
   Alias for update/2 for consistency with LiveView naming.
@@ -1397,24 +1626,30 @@ defmodule PhoenixKitEntities.EntityData do
   end
 
   @doc """
-  Bulk deletes multiple records by UUIDs.
+  Bulk hard-deletes records by UUIDs.
 
-  Returns a tuple with the count of deleted records and nil. Logs a
-  single `entity_data.bulk_deleted` activity row carrying the count
-  (not the uuids — they're already gone, and listing them in metadata
-  bloats the audit row).
+  Prefer `bulk_trash/2` for soft-delete. Use this for emptying-the-trash
+  flows where the records are confirmed unreferenced.
+
+  Catches `Postgrex.Error` for FK / NOT NULL violations and returns
+  `{:error, :referenced_by_external}` so the admin UI can flash a
+  friendly message rather than 500. The transaction rolls back on this
+  error — no records are deleted.
 
   ## Options
 
     * `:actor_uuid` — UUID of the user performing the bulk delete.
-      Threaded through to the activity log entry.
 
   ## Examples
 
       iex> PhoenixKitEntities.EntityData.bulk_delete(["uuid1", "uuid2"], actor_uuid: admin.uuid)
       {2, nil}
+
+      iex> PhoenixKitEntities.EntityData.bulk_delete([referenced_uuid])
+      {:error, :referenced_by_external}
   """
-  @spec bulk_delete([String.t()], keyword()) :: {non_neg_integer(), nil}
+  @spec bulk_delete([String.t()], keyword()) ::
+          {non_neg_integer(), nil} | {:error, :referenced_by_external}
   def bulk_delete(uuids, opts \\ []) when is_list(uuids) do
     {count, _} =
       result =
@@ -1433,13 +1668,104 @@ defmodule PhoenixKitEntities.EntityData do
     })
 
     result
+  rescue
+    e in Postgrex.Error ->
+      if foreign_key_or_not_null_violation?(e) do
+        log_data_error_activity(:bulk_deleted, opts)
+        {:error, :referenced_by_external}
+      else
+        reraise e, __STACKTRACE__
+      end
+  end
+
+  @doc """
+  Bulk soft-deletes records by setting their status to `"trashed"`.
+
+  Returns `{count, nil}` for the number of records actually trashed
+  (already-trashed records are skipped via the WHERE clause). Logs a
+  single `entity_data.bulk_trashed` row.
+
+  ## Examples
+
+      iex> EntityData.bulk_trash(["uuid1", "uuid2"], actor_uuid: admin.uuid)
+      {2, nil}
+  """
+  @spec bulk_trash([String.t()], keyword()) :: {non_neg_integer(), nil}
+  def bulk_trash(uuids, opts \\ []) when is_list(uuids) do
+    now = UtilsDate.utc_now()
+
+    {count, _} =
+      result =
+      from(d in __MODULE__,
+        where: d.uuid in ^uuids and d.status != ^@soft_delete_status
+      )
+      |> repo().update_all(set: [status: @soft_delete_status, date_updated: now])
+
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: "entity_data.bulk_trashed",
+      mode: "manual",
+      actor_uuid: Keyword.get(opts, :actor_uuid),
+      resource_type: "entity_data",
+      metadata: %{"count" => count, "uuid_count" => length(uuids)}
+    })
+
+    # Broadcast per affected entity so any LV viewing those records refreshes.
+    broadcast_bulk_change(uuids)
+
+    result
+  end
+
+  @doc """
+  Bulk restores trashed records to `"published"` status.
+
+  Only rows currently `"trashed"` are touched. Logs
+  `entity_data.bulk_restored` with the affected count.
+
+  ## Examples
+
+      iex> EntityData.bulk_restore_from_trash(["uuid1", "uuid2"], actor_uuid: admin.uuid)
+      {2, nil}
+  """
+  @spec bulk_restore_from_trash([String.t()], keyword()) :: {non_neg_integer(), nil}
+  def bulk_restore_from_trash(uuids, opts \\ []) when is_list(uuids) do
+    now = UtilsDate.utc_now()
+
+    {count, _} =
+      result =
+      from(d in __MODULE__,
+        where: d.uuid in ^uuids and d.status == ^@soft_delete_status
+      )
+      |> repo().update_all(set: [status: "published", date_updated: now])
+
+    PhoenixKitEntities.ActivityLog.log(%{
+      action: "entity_data.bulk_restored",
+      mode: "manual",
+      actor_uuid: Keyword.get(opts, :actor_uuid),
+      resource_type: "entity_data",
+      metadata: %{"count" => count, "uuid_count" => length(uuids)}
+    })
+
+    broadcast_bulk_change(uuids)
+
+    result
+  end
+
+  # Look up the entity_uuid for each affected row and broadcast a
+  # data_updated event per (entity, record) pair so any open LV refreshes.
+  defp broadcast_bulk_change(uuids) when is_list(uuids) do
+    from(d in __MODULE__, where: d.uuid in ^uuids, select: {d.entity_uuid, d.uuid})
+    |> repo().all()
+    |> Enum.each(fn {entity_uuid, uuid} ->
+      Events.broadcast_data_updated(entity_uuid, uuid)
+    end)
   end
 
   @doc """
   Gets statistical data about entity data records.
 
-  Returns statistics about total records, published, draft, and archived counts.
-  Optionally filters by entity_uuid if provided.
+  `total_records` is the count of *non-trashed* records (the visible
+  total). `trashed_records` is reported separately so the admin can
+  surface the trash-bin badge.
 
   ## Examples
 
@@ -1448,25 +1774,19 @@ defmodule PhoenixKitEntities.EntityData do
         total_records: 150,
         published_records: 120,
         draft_records: 25,
-        archived_records: 5
-      }
-
-      iex> PhoenixKitEntities.EntityData.get_data_stats("018e3c4a-9f6b-7890-abcd-ef1234567890")
-      %{
-        total_records: 15,
-        published_records: 12,
-        draft_records: 2,
-        archived_records: 1
+        archived_records: 5,
+        trashed_records: 3
       }
   """
   def get_data_stats(entity_uuid \\ nil) do
     query =
       from(d in __MODULE__,
         select: {
-          count(d.uuid),
+          count(fragment("CASE WHEN ? <> 'trashed' THEN 1 END", d.status)),
           count(fragment("CASE WHEN ? = 'published' THEN 1 END", d.status)),
           count(fragment("CASE WHEN ? = 'draft' THEN 1 END", d.status)),
-          count(fragment("CASE WHEN ? = 'archived' THEN 1 END", d.status))
+          count(fragment("CASE WHEN ? = 'archived' THEN 1 END", d.status)),
+          count(fragment("CASE WHEN ? = 'trashed' THEN 1 END", d.status))
         }
       )
 
@@ -1479,13 +1799,14 @@ defmodule PhoenixKitEntities.EntityData do
           from(d in query, where: d.entity_uuid == ^uuid)
       end
 
-    {total, published, draft, archived} = repo().one(query)
+    {total, published, draft, archived, trashed} = repo().one(query)
 
     %{
       total_records: total,
       published_records: published,
       draft_records: draft,
-      archived_records: archived
+      archived_records: archived,
+      trashed_records: trashed
     }
   end
 

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -627,6 +627,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.list_trashed_by_entity(entity_uuid)
       [%PhoenixKitEntities.EntityData{status: "trashed"}, ...]
   """
+  @spec list_trashed_by_entity(binary(), keyword()) :: [t()]
   def list_trashed_by_entity(entity_uuid, opts \\ []) when is_binary(entity_uuid) do
     from(d in __MODULE__,
       where: d.entity_uuid == ^entity_uuid and d.status == ^@soft_delete_status,
@@ -1272,6 +1273,7 @@ defmodule PhoenixKitEntities.EntityData do
   @doc """
   Counts trashed records for an entity. Drives the trash-bin badge.
   """
+  @spec trashed_count(binary()) :: non_neg_integer()
   def trashed_count(entity_uuid) when is_binary(entity_uuid) do
     from(d in __MODULE__,
       where: d.entity_uuid == ^entity_uuid and d.status == ^@soft_delete_status,

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -1536,9 +1536,23 @@ defmodule PhoenixKitEntities.EntityData do
   integer. Returns the total count across all matching callbacks for
   the record's entity, or `0` if no callbacks are registered.
 
-  This is informational, not a delete-blocker — soft-delete keeps the
-  row alive regardless. Used by the admin to render "Used by N rows"
-  hints before the operator clicks Trash or Permanently delete.
+  **Informational only — NOT a delete-blocker.** Soft-delete keeps the
+  row alive regardless of how many parent rows reference it; this
+  count is just for the admin UI to surface "Used by N rows" hints
+  before the operator clicks Trash or Permanently delete. Don't wire
+  it into the actual delete path.
+
+  ## Performance — pass `entity` when the caller already has it
+
+  The single-arg form preloads `:entity` on every call. When rendering
+  many records (e.g. the admin trash bin), pass the already-loaded
+  entity as the second arg to skip the per-call N+1:
+
+      entity = Entities.get_entity!(entity_uuid)
+
+      Enum.map(records, fn record ->
+        EntityData.count_external_references(record, entity)
+      end)
 
   ## Configuration
 
@@ -1548,31 +1562,50 @@ defmodule PhoenixKitEntities.EntityData do
           {"order_status", &MyApp.Orders.count_orders_with_status/1},
           {"sub_order_status", &MyApp.Orders.count_sub_orders_with_status/1}
         ]
+
+  Multiple callbacks per entity name are supported — every matching
+  tuple's count contributes to the total. Useful when the same
+  entity_data acts as a controlled vocabulary for several parent
+  tables (e.g. `orders` and `audit_log` both referencing
+  `order_status`).
   """
   @spec count_external_references(t()) :: non_neg_integer()
-  def count_external_references(%__MODULE__{} = entity_data) do
-    entity = repo().preload(entity_data, :entity).entity
+  @spec count_external_references(t(), map() | nil) :: non_neg_integer()
+  def count_external_references(entity_data, entity \\ nil)
 
-    case entity do
-      %{name: name} when is_binary(name) ->
-        :phoenix_kit_entities
-        |> Application.get_env(:reverse_references, [])
-        |> Enum.filter(fn
-          {^name, fun} when is_function(fun, 1) -> true
-          _ -> false
-        end)
-        |> Enum.reduce(0, fn {_name, fun}, acc ->
-          try do
-            count = fun.(entity_data.uuid)
-            if is_integer(count) and count >= 0, do: acc + count, else: acc
-          rescue
-            _ -> acc
-          end
-        end)
+  def count_external_references(%__MODULE__{} = entity_data, %{name: name})
+      when is_binary(name) do
+    do_count_external_references(entity_data, name)
+  end
 
-      _ ->
-        0
+  def count_external_references(%__MODULE__{} = entity_data, nil) do
+    # Fall back to a per-call preload when the caller didn't pass an
+    # entity. Always exits to do_count_external_references/2 or to 0 —
+    # never re-enters this clause, so the orphan-entity case can't
+    # recurse infinitely.
+    case repo().preload(entity_data, :entity).entity do
+      %{name: name} when is_binary(name) -> do_count_external_references(entity_data, name)
+      _ -> 0
     end
+  end
+
+  def count_external_references(%__MODULE__{}, _), do: 0
+
+  defp do_count_external_references(entity_data, name) when is_binary(name) do
+    :phoenix_kit_entities
+    |> Application.get_env(:reverse_references, [])
+    |> Enum.filter(fn
+      {^name, fun} when is_function(fun, 1) -> true
+      _ -> false
+    end)
+    |> Enum.reduce(0, fn {_name, fun}, acc ->
+      try do
+        count = fun.(entity_data.uuid)
+        if is_integer(count) and count >= 0, do: acc + count, else: acc
+      rescue
+        _ -> acc
+      end
+    end)
   end
 
   @doc """

--- a/lib/phoenix_kit_entities/errors.ex
+++ b/lib/phoenix_kit_entities/errors.ex
@@ -43,6 +43,9 @@ defmodule PhoenixKitEntities.Errors do
           | :not_found
           | :invalid_format
           | :unexpected
+          | :already_trashed
+          | :not_trashed
+          | :referenced_by_external
 
   @typedoc """
   Tagged tuples carrying interpolation context.
@@ -64,6 +67,14 @@ defmodule PhoenixKitEntities.Errors do
   def message(:not_found), do: gettext("Record not found.")
   def message(:invalid_format), do: gettext("Invalid format.")
   def message(:unexpected), do: gettext("An unexpected error occurred.")
+  def message(:already_trashed), do: gettext("This record is already in the trash.")
+  def message(:not_trashed), do: gettext("This record is not in the trash.")
+
+  def message(:referenced_by_external) do
+    gettext(
+      "Cannot permanently delete: this record is referenced by other tables in the parent application. Restore it or remove the references first."
+    )
+  end
 
   def message({:invalid_field_type, type}) when is_binary(type) do
     gettext("Invalid field type: %{type}", type: type)

--- a/lib/phoenix_kit_entities/sitemap_source.ex
+++ b/lib/phoenix_kit_entities/sitemap_source.ex
@@ -138,15 +138,25 @@ defmodule PhoenixKitEntities.SitemapSource do
       nil
     end
   rescue
-    _ -> nil
+    error ->
+      Logger.warning("Sitemap: failed to build sub_sitemaps for entities: #{inspect(error)}")
+      nil
   end
 
+  # Defensive boot resilience — `enabled?/0` runs from sitemap generation
+  # paths that may execute before the DB is fully up (e.g. host-app boot
+  # scripts or cold cache scenarios). The rescue covers DB-availability
+  # exceptions; the `catch :exit, _` matches the canonical shape in
+  # `phoenix_kit_entities.ex:enabled?/0` for sandbox-shutdown signals
+  # that don't surface as exceptions.
   @impl true
   @spec enabled?() :: boolean()
   def enabled? do
     PhoenixKitEntities.enabled?()
   rescue
     _ -> false
+  catch
+    :exit, _ -> false
   end
 
   @impl true

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -1164,6 +1164,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                   <button
                     phx-click="bulk_action"
                     phx-value-action="restore_from_trash"
+                    phx-disable-with={gettext("…")}
                     class="btn btn-success btn-sm"
                   >
                     <.icon name="hero-arrow-uturn-left" class="w-4 h-4" /> {gettext("Restore")}
@@ -1171,6 +1172,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                   <button
                     phx-click="bulk_action"
                     phx-value-action="permanent_delete"
+                    phx-disable-with={gettext("…")}
                     class="btn btn-error btn-sm"
                     data-confirm={
                       gettext(
@@ -1186,6 +1188,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                   <button
                     phx-click="bulk_action"
                     phx-value-action="archive"
+                    phx-disable-with={gettext("…")}
                     class="btn btn-warning btn-sm"
                   >
                     <.icon name="hero-archive-box" class="w-4 h-4" /> {gettext("Archive")}
@@ -1193,6 +1196,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                   <button
                     phx-click="bulk_action"
                     phx-value-action="restore"
+                    phx-disable-with={gettext("…")}
                     class="btn btn-success btn-sm"
                   >
                     <.icon name="hero-arrow-path" class="w-4 h-4" /> {gettext("Restore")}
@@ -1200,6 +1204,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                   <button
                     phx-click="bulk_action"
                     phx-value-action="trash"
+                    phx-disable-with={gettext("…")}
                     class="btn btn-error btn-sm"
                     data-confirm={
                       gettext(
@@ -1230,6 +1235,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                         phx-click="bulk_action"
                         phx-value-action="change_status"
                         phx-value-status="published"
+                        phx-disable-with={gettext("…")}
                       >
                         {gettext("Published")}
                       </a>
@@ -1239,6 +1245,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                         phx-click="bulk_action"
                         phx-value-action="change_status"
                         phx-value-status="draft"
+                        phx-disable-with={gettext("…")}
                       >
                         {gettext("Draft")}
                       </a>
@@ -1248,6 +1255,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                         phx-click="bulk_action"
                         phx-value-action="change_status"
                         phx-value-status="archived"
+                        phx-disable-with={gettext("…")}
                       >
                         {gettext("Archived")}
                       </a>

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -44,6 +44,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
       |> assign(:published_records, 0)
       |> assign(:draft_records, 0)
       |> assign(:archived_records, 0)
+      |> assign(:trashed_records, 0)
       |> assign(:selected_entity, nil)
       |> assign(:selected_entity_uuid, nil)
       |> assign(:selected_status, "all")
@@ -139,6 +140,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     |> assign(:published_records, stats.published_records)
     |> assign(:draft_records, stats.draft_records)
     |> assign(:archived_records, stats.archived_records)
+    |> assign(:trashed_records, stats.trashed_records)
   end
 
   @impl true
@@ -297,15 +299,93 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     end
   end
 
+  def handle_event("trash_data", %{"uuid" => uuid}, socket) do
+    if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
+      data_record = EntityData.get!(uuid)
+
+      case EntityData.trash(data_record, actor_opts(socket)) do
+        {:ok, _data} ->
+          {:noreply,
+           socket
+           |> refresh_data_stats()
+           |> apply_filters()
+           |> put_flash(
+             :info,
+             gettext("Record moved to trash. Restore it before %{days} days to keep it.",
+               days: 90
+             )
+           )}
+
+        {:error, :already_trashed} ->
+          {:noreply, put_flash(socket, :info, gettext("Record is already in the trash"))}
+
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, gettext("Failed to trash record"))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+    end
+  end
+
+  def handle_event("restore_from_trash", %{"uuid" => uuid}, socket) do
+    if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
+      data_record = EntityData.get!(uuid)
+
+      case EntityData.restore_from_trash(data_record, actor_opts(socket)) do
+        {:ok, _data} ->
+          {:noreply,
+           socket
+           |> refresh_data_stats()
+           |> apply_filters()
+           |> put_flash(:info, gettext("Record restored from trash"))}
+
+        {:error, :not_trashed} ->
+          {:noreply, put_flash(socket, :info, gettext("Record is not in the trash"))}
+
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, gettext("Failed to restore record"))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+    end
+  end
+
+  def handle_event("permanent_delete", %{"uuid" => uuid}, socket) do
+    if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
+      data_record = EntityData.get!(uuid)
+
+      case EntityData.delete(data_record, actor_opts(socket)) do
+        {:ok, _data} ->
+          {:noreply,
+           socket
+           |> refresh_data_stats()
+           |> apply_filters()
+           |> put_flash(:info, gettext("Record permanently deleted"))}
+
+        {:error, :referenced_by_external} ->
+          {:noreply,
+           put_flash(socket, :error, PhoenixKitEntities.Errors.message(:referenced_by_external))}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, gettext("Failed to delete record"))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+    end
+  end
+
   def handle_event("toggle_status", %{"uuid" => uuid}, socket) do
     if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
       data_record = EntityData.get!(uuid)
 
+      # Trashed records are excluded from the cycle — restore them
+      # explicitly via the dedicated Restore button instead.
       new_status =
         case data_record.status do
           "draft" -> "published"
           "published" -> "archived"
           "archived" -> "draft"
+          "trashed" -> "trashed"
         end
 
       case EntityData.update_data(data_record, %{status: new_status}, actor_opts(socket)) do
@@ -417,24 +497,66 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     end
   end
 
+  # Bulk "delete" is a soft-delete (trash) — keeps rows alive so parent-app
+  # FK references stay valid. Use the "permanent_delete" action below from
+  # the Trash filter view to actually remove rows.
   def handle_event("bulk_action", %{"action" => "delete"}, socket) do
+    handle_event("bulk_action", %{"action" => "trash"}, socket)
+  end
+
+  def handle_event("bulk_action", %{"action" => "trash"}, socket) do
     if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
       uuids = socket.assigns.selected_uuids
 
       if MapSet.size(uuids) == 0 do
         {:noreply, put_flash(socket, :error, gettext("No records selected"))}
       else
-        {count, _} = EntityData.bulk_delete(MapSet.to_list(uuids), actor_opts(socket))
+        {count, _} = EntityData.bulk_trash(MapSet.to_list(uuids), actor_opts(socket))
 
         {:noreply,
          socket
          |> assign(:selected_uuids, MapSet.new())
          |> refresh_data_stats()
          |> apply_filters()
-         |> put_flash(:info, gettext("%{count} records deleted", count: count))}
+         |> put_flash(:info, gettext("%{count} records moved to trash", count: count))}
       end
     else
       {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+    end
+  end
+
+  def handle_event("bulk_action", %{"action" => "restore_from_trash"}, socket) do
+    if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
+      uuids = socket.assigns.selected_uuids
+
+      if MapSet.size(uuids) == 0 do
+        {:noreply, put_flash(socket, :error, gettext("No records selected"))}
+      else
+        {count, _} =
+          EntityData.bulk_restore_from_trash(MapSet.to_list(uuids), actor_opts(socket))
+
+        {:noreply,
+         socket
+         |> assign(:selected_uuids, MapSet.new())
+         |> refresh_data_stats()
+         |> apply_filters()
+         |> put_flash(:info, gettext("%{count} records restored from trash", count: count))}
+      end
+    else
+      {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+    end
+  end
+
+  def handle_event("bulk_action", %{"action" => "permanent_delete"}, socket) do
+    cond do
+      not Scope.admin?(socket.assigns.phoenix_kit_current_scope) ->
+        {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+
+      MapSet.size(socket.assigns.selected_uuids) == 0 ->
+        {:noreply, put_flash(socket, :error, gettext("No records selected"))}
+
+      true ->
+        do_bulk_permanent_delete(socket)
     end
   end
 
@@ -457,6 +579,24 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
       end
     else
       {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+    end
+  end
+
+  defp do_bulk_permanent_delete(socket) do
+    uuids = socket.assigns.selected_uuids
+
+    case EntityData.bulk_delete(MapSet.to_list(uuids), actor_opts(socket)) do
+      {count, _} when is_integer(count) ->
+        {:noreply,
+         socket
+         |> assign(:selected_uuids, MapSet.new())
+         |> refresh_data_stats()
+         |> apply_filters()
+         |> put_flash(:info, gettext("%{count} records permanently deleted", count: count))}
+
+      {:error, :referenced_by_external} ->
+        {:noreply,
+         put_flash(socket, :error, PhoenixKitEntities.Errors.message(:referenced_by_external))}
     end
   end
 
@@ -659,10 +799,14 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
 
   # When an entity is selected, use sort-mode-aware queries
   defp fetch_records(nil, "all", _opts), do: EntityData.list_all_data()
+  defp fetch_records(nil, "trashed", _opts), do: EntityData.list_data_by_status("trashed")
   defp fetch_records(nil, status, _opts), do: EntityData.list_data_by_status(status)
 
   defp fetch_records(entity_uuid, "all", opts),
     do: EntityData.list_by_entity(entity_uuid, opts)
+
+  defp fetch_records(entity_uuid, "trashed", opts),
+    do: EntityData.list_trashed_by_entity(entity_uuid, opts)
 
   defp fetch_records(entity_uuid, status, opts),
     do: EntityData.list_by_entity_and_status(entity_uuid, status, opts)
@@ -688,6 +832,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     |> assign(:published_records, stats.published_records)
     |> assign(:draft_records, stats.draft_records)
     |> assign(:archived_records, stats.archived_records)
+    |> assign(:trashed_records, stats.trashed_records)
   end
 
   defp refresh_entities_and_data(socket) do
@@ -704,6 +849,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
       "published" -> "badge-success"
       "draft" -> "badge-warning"
       "archived" -> "badge-neutral"
+      "trashed" -> "badge-error"
       _ -> "badge-outline"
     end
   end
@@ -713,6 +859,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
       "published" -> gettext("Published")
       "draft" -> gettext("Draft")
       "archived" -> gettext("Archived")
+      "trashed" -> gettext("Trashed")
       _ -> gettext("Unknown")
     end
   end
@@ -722,6 +869,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
       "published" -> "hero-check-circle"
       "draft" -> "hero-pencil"
       "archived" -> "hero-archive-box"
+      "trashed" -> "hero-trash"
       _ -> "hero-question-mark-circle"
     end
   end
@@ -962,6 +1110,9 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                       <option value="archived" selected={@selected_status == "archived"}>
                         {gettext("Archived")}
                       </option>
+                      <option value="trashed" selected={@selected_status == "trashed"}>
+                        {gettext("Trash")}{if @trashed_records > 0, do: " (#{@trashed_records})", else: ""}
+                      </option>
                     </select>
                   </label>
                 </.form>
@@ -1008,32 +1159,58 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                 </span>
                 <div class="divider divider-horizontal mx-0"></div>
                 <%!-- Quick Actions --%>
-                <button
-                  phx-click="bulk_action"
-                  phx-value-action="archive"
-                  class="btn btn-warning btn-sm"
-                >
-                  <.icon name="hero-archive-box" class="w-4 h-4" /> {gettext("Archive")}
-                </button>
-                <button
-                  phx-click="bulk_action"
-                  phx-value-action="restore"
-                  class="btn btn-success btn-sm"
-                >
-                  <.icon name="hero-arrow-path" class="w-4 h-4" /> {gettext("Restore")}
-                </button>
-                <button
-                  phx-click="bulk_action"
-                  phx-value-action="delete"
-                  class="btn btn-error btn-sm"
-                  data-confirm={
-                    gettext("Are you sure you want to delete %{count} records?",
-                      count: MapSet.size(@selected_uuids)
-                    )
-                  }
-                >
-                  <.icon name="hero-trash" class="w-4 h-4" /> {gettext("Delete")}
-                </button>
+                <%= if @selected_status == "trashed" do %>
+                  <%!-- Trash-bin actions: restore or permanently delete --%>
+                  <button
+                    phx-click="bulk_action"
+                    phx-value-action="restore_from_trash"
+                    class="btn btn-success btn-sm"
+                  >
+                    <.icon name="hero-arrow-uturn-left" class="w-4 h-4" /> {gettext("Restore")}
+                  </button>
+                  <button
+                    phx-click="bulk_action"
+                    phx-value-action="permanent_delete"
+                    class="btn btn-error btn-sm"
+                    data-confirm={
+                      gettext(
+                        "Permanently delete %{count} records? This cannot be undone, and will fail if any are still referenced by other tables.",
+                        count: MapSet.size(@selected_uuids)
+                      )
+                    }
+                  >
+                    <.icon name="hero-x-circle" class="w-4 h-4" />
+                    {gettext("Delete forever")}
+                  </button>
+                <% else %>
+                  <button
+                    phx-click="bulk_action"
+                    phx-value-action="archive"
+                    class="btn btn-warning btn-sm"
+                  >
+                    <.icon name="hero-archive-box" class="w-4 h-4" /> {gettext("Archive")}
+                  </button>
+                  <button
+                    phx-click="bulk_action"
+                    phx-value-action="restore"
+                    class="btn btn-success btn-sm"
+                  >
+                    <.icon name="hero-arrow-path" class="w-4 h-4" /> {gettext("Restore")}
+                  </button>
+                  <button
+                    phx-click="bulk_action"
+                    phx-value-action="trash"
+                    class="btn btn-error btn-sm"
+                    data-confirm={
+                      gettext(
+                        "Move %{count} records to the trash? Restore from the Trash filter if needed.",
+                        count: MapSet.size(@selected_uuids)
+                      )
+                    }
+                  >
+                    <.icon name="hero-trash" class="w-4 h-4" /> {gettext("Trash")}
+                  </button>
+                <% end %>
 
                 <div class="divider divider-horizontal mx-0"></div>
 
@@ -1322,28 +1499,75 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                           <.icon name="hero-pencil" class="w-4 h-4 hidden sm:inline" />
                           <span class="sm:hidden whitespace-nowrap">{gettext("Edit")}</span>
                         </.link>
-                        <%= if data_record.status == "archived" do %>
-                          <button
-                            class="btn btn-outline btn-xs text-success tooltip tooltip-bottom"
-                            phx-click="restore_data"
-                            phx-value-uuid={data_record.uuid}
-                            phx-disable-with={gettext("…")}
-                            data-tip={gettext("Restore")}
-                          >
-                            <.icon name="hero-arrow-path" class="w-4 h-4 hidden sm:inline" />
-                            <span class="sm:hidden whitespace-nowrap">{gettext("Restore")}</span>
-                          </button>
-                        <% else %>
-                          <button
-                            class="btn btn-outline btn-xs text-error tooltip tooltip-bottom"
-                            phx-click="archive_data"
-                            phx-value-uuid={data_record.uuid}
-                            phx-disable-with={gettext("…")}
-                            data-tip={gettext("Archive")}
-                          >
-                            <.icon name="hero-trash" class="w-4 h-4 hidden sm:inline" />
-                            <span class="sm:hidden whitespace-nowrap">{gettext("Archive")}</span>
-                          </button>
+                        <%= cond do %>
+                          <% data_record.status == "trashed" -> %>
+                            <button
+                              class="btn btn-outline btn-xs text-success tooltip tooltip-bottom"
+                              phx-click="restore_from_trash"
+                              phx-value-uuid={data_record.uuid}
+                              phx-disable-with={gettext("…")}
+                              data-tip={gettext("Restore from trash")}
+                            >
+                              <.icon name="hero-arrow-uturn-left" class="w-4 h-4 hidden sm:inline" />
+                              <span class="sm:hidden whitespace-nowrap">{gettext("Restore")}</span>
+                            </button>
+                            <button
+                              class="btn btn-outline btn-xs text-error tooltip tooltip-bottom"
+                              phx-click="permanent_delete"
+                              phx-value-uuid={data_record.uuid}
+                              phx-disable-with={gettext("…")}
+                              data-tip={gettext("Delete forever")}
+                              data-confirm={
+                                gettext(
+                                  "Permanently delete this record? This cannot be undone, and will fail if it's still referenced by other tables."
+                                )
+                              }
+                            >
+                              <.icon name="hero-x-circle" class="w-4 h-4 hidden sm:inline" />
+                              <span class="sm:hidden whitespace-nowrap">{gettext("Delete")}</span>
+                            </button>
+                          <% data_record.status == "archived" -> %>
+                            <button
+                              class="btn btn-outline btn-xs text-success tooltip tooltip-bottom"
+                              phx-click="restore_data"
+                              phx-value-uuid={data_record.uuid}
+                              phx-disable-with={gettext("…")}
+                              data-tip={gettext("Restore")}
+                            >
+                              <.icon name="hero-arrow-path" class="w-4 h-4 hidden sm:inline" />
+                              <span class="sm:hidden whitespace-nowrap">{gettext("Restore")}</span>
+                            </button>
+                            <button
+                              class="btn btn-outline btn-xs text-error tooltip tooltip-bottom"
+                              phx-click="trash_data"
+                              phx-value-uuid={data_record.uuid}
+                              phx-disable-with={gettext("…")}
+                              data-tip={gettext("Move to trash")}
+                            >
+                              <.icon name="hero-trash" class="w-4 h-4 hidden sm:inline" />
+                              <span class="sm:hidden whitespace-nowrap">{gettext("Trash")}</span>
+                            </button>
+                          <% true -> %>
+                            <button
+                              class="btn btn-outline btn-xs text-warning tooltip tooltip-bottom"
+                              phx-click="archive_data"
+                              phx-value-uuid={data_record.uuid}
+                              phx-disable-with={gettext("…")}
+                              data-tip={gettext("Archive")}
+                            >
+                              <.icon name="hero-archive-box" class="w-4 h-4 hidden sm:inline" />
+                              <span class="sm:hidden whitespace-nowrap">{gettext("Archive")}</span>
+                            </button>
+                            <button
+                              class="btn btn-outline btn-xs text-error tooltip tooltip-bottom"
+                              phx-click="trash_data"
+                              phx-value-uuid={data_record.uuid}
+                              phx-disable-with={gettext("…")}
+                              data-tip={gettext("Move to trash")}
+                            >
+                              <.icon name="hero-trash" class="w-4 h-4 hidden sm:inline" />
+                              <span class="sm:hidden whitespace-nowrap">{gettext("Trash")}</span>
+                            </button>
                         <% end %>
                       </div>
                     </.table_default_cell>
@@ -1484,27 +1708,70 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                       <.icon name="hero-pencil" class="w-4 h-4 mr-1" /> {gettext("Edit")}
                     </.link>
 
-                    <%!-- Archive/Restore Button --%>
-                    <%= if data_record.status == "archived" do %>
-                      <button
-                        class="btn btn-success btn-sm"
-                        phx-click="restore_data"
-                        phx-value-uuid={data_record.uuid}
-                        phx-disable-with={gettext("…")}
-                        title={gettext("Restore data record")}
-                      >
-                        <.icon name="hero-arrow-path" class="w-4 h-4" />
-                      </button>
-                    <% else %>
-                      <button
-                        class="btn btn-error btn-sm"
-                        phx-click="archive_data"
-                        phx-value-uuid={data_record.uuid}
-                        phx-disable-with={gettext("…")}
-                        title={gettext("Archive data record")}
-                      >
-                        <.icon name="hero-trash" class="w-4 h-4" />
-                      </button>
+                    <%!-- Archive / Trash / Restore / Permanent-delete buttons --%>
+                    <%= cond do %>
+                      <% data_record.status == "trashed" -> %>
+                        <button
+                          class="btn btn-success btn-sm"
+                          phx-click="restore_from_trash"
+                          phx-value-uuid={data_record.uuid}
+                          phx-disable-with={gettext("…")}
+                          title={gettext("Restore from trash")}
+                        >
+                          <.icon name="hero-arrow-uturn-left" class="w-4 h-4" />
+                        </button>
+                        <button
+                          class="btn btn-error btn-sm"
+                          phx-click="permanent_delete"
+                          phx-value-uuid={data_record.uuid}
+                          phx-disable-with={gettext("…")}
+                          title={gettext("Delete forever")}
+                          data-confirm={
+                            gettext(
+                              "Permanently delete this record? This cannot be undone, and will fail if it's still referenced by other tables."
+                            )
+                          }
+                        >
+                          <.icon name="hero-x-circle" class="w-4 h-4" />
+                        </button>
+                      <% data_record.status == "archived" -> %>
+                        <button
+                          class="btn btn-success btn-sm"
+                          phx-click="restore_data"
+                          phx-value-uuid={data_record.uuid}
+                          phx-disable-with={gettext("…")}
+                          title={gettext("Restore data record")}
+                        >
+                          <.icon name="hero-arrow-path" class="w-4 h-4" />
+                        </button>
+                        <button
+                          class="btn btn-error btn-sm"
+                          phx-click="trash_data"
+                          phx-value-uuid={data_record.uuid}
+                          phx-disable-with={gettext("…")}
+                          title={gettext("Move to trash")}
+                        >
+                          <.icon name="hero-trash" class="w-4 h-4" />
+                        </button>
+                      <% true -> %>
+                        <button
+                          class="btn btn-warning btn-sm"
+                          phx-click="archive_data"
+                          phx-value-uuid={data_record.uuid}
+                          phx-disable-with={gettext("…")}
+                          title={gettext("Archive data record")}
+                        >
+                          <.icon name="hero-archive-box" class="w-4 h-4" />
+                        </button>
+                        <button
+                          class="btn btn-error btn-sm"
+                          phx-click="trash_data"
+                          phx-value-uuid={data_record.uuid}
+                          phx-disable-with={gettext("…")}
+                          title={gettext("Move to trash")}
+                        >
+                          <.icon name="hero-trash" class="w-4 h-4" />
+                        </button>
                     <% end %>
                   </div>
                 </div>

--- a/test/phoenix_kit_entities/entity_data_trash_test.exs
+++ b/test/phoenix_kit_entities/entity_data_trash_test.exs
@@ -378,12 +378,22 @@ defmodule PhoenixKitEntities.EntityDataTrashTest do
       )
 
       uuids = Enum.map(ctx.records, & &1.uuid)
-      assert {:error, :referenced_by_external} = EntityData.bulk_delete(uuids)
+
+      assert {:error, :referenced_by_external} =
+               EntityData.bulk_delete(uuids, actor_uuid: ctx.actor_uuid)
 
       # Transaction rolled back — every record still exists.
       Enum.each(uuids, fn uuid ->
         assert %EntityData{} = EntityData.get(uuid)
       end)
+
+      # Pin the audit row — covers the user-initiated bulk delete attempt
+      # even though the DB rolled back. `db_pending: true` differentiates
+      # this from a successful bulk_deleted row.
+      assert_activity_logged("entity_data.bulk_deleted",
+        actor_uuid: ctx.actor_uuid,
+        metadata_has: %{"db_pending" => true}
+      )
     end
 
     test "delete/2 surfaces NOT NULL violation as :referenced_by_external (issue #12 case)",

--- a/test/phoenix_kit_entities/entity_data_trash_test.exs
+++ b/test/phoenix_kit_entities/entity_data_trash_test.exs
@@ -652,6 +652,47 @@ defmodule PhoenixKitEntities.EntityDataTrashTest do
 
       assert EntityData.count_external_references(orphan) == 0
     end
+
+    test "2-arity form accepts a preloaded entity to skip the per-call preload", ctx do
+      # The single-arg form does `repo().preload(entity_data, :entity).entity`
+      # on every call — N+1 when rendering many records. The 2-arity form
+      # lets callers pass an already-loaded entity (or any map with a
+      # binary `:name` key) to avoid the round-trip.
+      [record | _] = ctx.records
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"trash_test", fn _uuid -> 11 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      # Same numeric result whether we pass the entity or let it preload.
+      preloaded = Entities.get_entity!(ctx.entity.uuid)
+      assert EntityData.count_external_references(record, preloaded) == 11
+      assert EntityData.count_external_references(record) == 11
+
+      # A bare-shape map with the right :name still works — useful for
+      # callers that have entity name in a custom struct (sitemap source,
+      # mirror exporter, etc.).
+      assert EntityData.count_external_references(record, %{name: "trash_test"}) == 11
+    end
+
+    test "2-arity form returns 0 when entity is nil-but-explicit (no preload, no DB hit)" do
+      # Useful belt-and-suspenders for callers that want to bypass the
+      # preload AND know the entity isn't in their working set.
+      orphan = %EntityData{uuid: UUID.generate(), entity_uuid: UUID.generate()}
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"trash_test", fn _uuid -> 99 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      # Passing a non-name-bearing value collapses to 0 without falling
+      # through to the preload path.
+      assert EntityData.count_external_references(orphan, %{}) == 0
+      assert EntityData.count_external_references(orphan, "not a struct") == 0
+    end
   end
 
   defp repo, do: PhoenixKit.RepoHelper.repo()

--- a/test/phoenix_kit_entities/entity_data_trash_test.exs
+++ b/test/phoenix_kit_entities/entity_data_trash_test.exs
@@ -1,0 +1,648 @@
+defmodule PhoenixKitEntities.EntityDataTrashTest do
+  @moduledoc """
+  Soft-delete (trash) + restore + permanent-delete behaviour for
+  EntityData. Pinned by issue #12: parent apps with FK columns
+  pointing at `phoenix_kit_entity_data(uuid)` need a way to retire a
+  record without invalidating those FKs. The soft-delete flow keeps
+  the row alive so the FK stays satisfied; default list/search
+  queries hide trashed rows; the trash bin surfaces them for restore
+  or permanent deletion.
+  """
+
+  use PhoenixKitEntities.DataCase, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Ecto.UUID
+  alias PhoenixKitEntities, as: Entities
+  alias PhoenixKitEntities.ActivityLogAssertions
+  alias PhoenixKitEntities.EntityData
+  alias PhoenixKitEntities.Events
+
+  import ActivityLogAssertions
+  import Ecto.Query, only: [from: 2]
+
+  setup do
+    actor_uuid = UUID.generate()
+
+    {:ok, entity} =
+      Entities.create_entity(
+        %{
+          name: "trash_test",
+          display_name: "Trash Test",
+          display_name_plural: "Trash Tests",
+          fields_definition: [%{"type" => "text", "key" => "name", "label" => "Name"}],
+          status: "published",
+          created_by_uuid: actor_uuid
+        },
+        actor_uuid: actor_uuid
+      )
+
+    records =
+      for n <- 1..3 do
+        {:ok, r} =
+          EntityData.create(
+            %{
+              entity_uuid: entity.uuid,
+              title: "Record #{n}",
+              slug: "record-#{n}",
+              status: "published",
+              data: %{"name" => "Item #{n}"},
+              created_by_uuid: actor_uuid
+            },
+            actor_uuid: actor_uuid
+          )
+
+        r
+      end
+
+    {:ok, entity: entity, records: records, actor_uuid: actor_uuid}
+  end
+
+  describe "trash/2" do
+    test "flips status to trashed and logs entity_data.trashed", ctx do
+      [record | _] = ctx.records
+
+      assert {:ok, %EntityData{status: "trashed"}} =
+               EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      assert_activity_logged("entity_data.trashed",
+        actor_uuid: ctx.actor_uuid,
+        resource_uuid: record.uuid
+      )
+    end
+
+    test "refuses with :already_trashed when called twice", ctx do
+      [record | _] = ctx.records
+      {:ok, trashed} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      assert {:error, :already_trashed} = EntityData.trash(trashed, actor_uuid: ctx.actor_uuid)
+    end
+
+    test "row stays in DB — get/1 still resolves the uuid (so parent FKs hold)", ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      assert %EntityData{uuid: same_uuid, status: "trashed"} = EntityData.get(record.uuid)
+      assert same_uuid == record.uuid
+    end
+
+    test "trashed records hide from list_by_entity by default but surface with include_trashed",
+         ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record)
+
+      uuids_default = Enum.map(EntityData.list_by_entity(ctx.entity.uuid), & &1.uuid)
+
+      uuids_with =
+        Enum.map(EntityData.list_by_entity(ctx.entity.uuid, include_trashed: true), & &1.uuid)
+
+      refute record.uuid in uuids_default
+      assert record.uuid in uuids_with
+    end
+
+    test "single-arg trash/1 works (default opts)", ctx do
+      [record | _] = ctx.records
+      assert {:ok, %EntityData{status: "trashed"}} = EntityData.trash(record)
+    end
+
+    test "trash without actor_uuid still logs activity (actor_uuid falls back to creator)", ctx do
+      [record | _] = ctx.records
+      assert {:ok, _} = EntityData.trash(record)
+      # log_data_activity uses entity_data.created_by_uuid as the fallback
+      # actor when opts[:actor_uuid] is nil. This keeps the audit row
+      # populated even on programmatic / system-triggered trashes.
+      assert_activity_logged("entity_data.trashed",
+        actor_uuid: ctx.actor_uuid,
+        resource_uuid: record.uuid
+      )
+    end
+
+    test "broadcasts data_updated PubSub event after trash", ctx do
+      [record | _] = ctx.records
+      Events.subscribe_to_entity_data(ctx.entity.uuid)
+
+      {:ok, _} = EntityData.trash(record)
+
+      assert_receive {:data_updated, entity_uuid, data_uuid}, 1_000
+      assert entity_uuid == ctx.entity.uuid
+      assert data_uuid == record.uuid
+    end
+
+    test "date_updated bumps when trashing", ctx do
+      [record | _] = ctx.records
+      original = record.date_updated
+
+      # Manually backdate so the change is observable on a second-precision
+      # timestamp (dev_docs notes utc_datetime is second-precision; tests
+      # near-instant inserts can collide).
+      backdated = DateTime.add(DateTime.utc_now(), -5, :second) |> DateTime.truncate(:second)
+
+      from(d in EntityData, where: d.uuid == ^record.uuid)
+      |> repo().update_all(set: [date_updated: backdated])
+
+      reloaded = EntityData.get(record.uuid)
+      assert {:ok, trashed} = EntityData.trash(reloaded)
+      assert DateTime.compare(trashed.date_updated, original) in [:gt, :eq]
+      refute DateTime.compare(trashed.date_updated, backdated) == :eq
+    end
+  end
+
+  describe "restore_from_trash/2" do
+    test "moves a trashed record back to published and logs entity_data.restored", ctx do
+      [record | _] = ctx.records
+      {:ok, trashed} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      assert {:ok, %EntityData{status: "published"}} =
+               EntityData.restore_from_trash(trashed, actor_uuid: ctx.actor_uuid)
+
+      assert_activity_logged("entity_data.restored",
+        actor_uuid: ctx.actor_uuid,
+        resource_uuid: record.uuid
+      )
+    end
+
+    test "refuses with :not_trashed for a non-trashed record", ctx do
+      [record | _] = ctx.records
+      assert {:error, :not_trashed} = EntityData.restore_from_trash(record)
+    end
+
+    test "refuses :not_trashed for draft and archived records too (only trash→published)",
+         ctx do
+      [r1, r2, _] = ctx.records
+      {:ok, draft} = EntityData.update(r1, %{status: "draft"})
+      {:ok, archived} = EntityData.update(r2, %{status: "archived"})
+
+      assert {:error, :not_trashed} = EntityData.restore_from_trash(draft)
+      assert {:error, :not_trashed} = EntityData.restore_from_trash(archived)
+    end
+
+    test "single-arg restore_from_trash/1 works", ctx do
+      [record | _] = ctx.records
+      {:ok, trashed} = EntityData.trash(record)
+      assert {:ok, %EntityData{status: "published"}} = EntityData.restore_from_trash(trashed)
+    end
+
+    test "broadcasts data_updated PubSub event after restore", ctx do
+      [record | _] = ctx.records
+      {:ok, trashed} = EntityData.trash(record)
+      Events.subscribe_to_entity_data(ctx.entity.uuid)
+
+      {:ok, _} = EntityData.restore_from_trash(trashed)
+
+      assert_receive {:data_updated, entity_uuid, data_uuid}, 1_000
+      assert entity_uuid == ctx.entity.uuid
+      assert data_uuid == record.uuid
+    end
+  end
+
+  describe "list_trashed_by_entity/2" do
+    test "returns only trashed records, ordered by most recently updated", ctx do
+      [r1, r2, r3] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+      {:ok, _} = EntityData.trash(r3)
+
+      result = EntityData.list_trashed_by_entity(ctx.entity.uuid)
+      uuids = Enum.map(result, & &1.uuid)
+
+      assert r1.uuid in uuids
+      assert r3.uuid in uuids
+      refute r2.uuid in uuids
+    end
+
+    test "returns empty list when nothing is trashed", ctx do
+      assert EntityData.list_trashed_by_entity(ctx.entity.uuid) == []
+    end
+  end
+
+  describe "trashed_count/1 + count_by_entity/2" do
+    test "trashed_count returns only trashed", ctx do
+      [r1, r2, _r3] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+      {:ok, _} = EntityData.trash(r2)
+
+      assert EntityData.trashed_count(ctx.entity.uuid) == 2
+    end
+
+    test "count_by_entity excludes trashed by default; include_trashed flips it", ctx do
+      [r1 | _] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      assert EntityData.count_by_entity(ctx.entity.uuid) == 2
+      assert EntityData.count_by_entity(ctx.entity.uuid, include_trashed: true) == 3
+    end
+  end
+
+  describe "get_data_stats/1" do
+    test "exposes trashed_records and excludes them from total_records", ctx do
+      [r1, r2, _r3] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+      {:ok, _} = EntityData.trash(r2)
+
+      stats = EntityData.get_data_stats(ctx.entity.uuid)
+
+      assert stats.trashed_records == 2
+      assert stats.total_records == 1
+      assert stats.published_records == 1
+    end
+  end
+
+  describe "bulk_trash/2 + bulk_restore_from_trash/2" do
+    test "bulk_trash flips selected records to trashed and logs ONE summary row", ctx do
+      uuids = Enum.map(ctx.records, & &1.uuid)
+
+      assert {3, _} = EntityData.bulk_trash(uuids, actor_uuid: ctx.actor_uuid)
+
+      assert_activity_logged("entity_data.bulk_trashed",
+        actor_uuid: ctx.actor_uuid,
+        metadata_has: %{"count" => 3, "uuid_count" => 3}
+      )
+
+      Enum.each(uuids, fn uuid ->
+        assert EntityData.get(uuid).status == "trashed"
+      end)
+    end
+
+    test "bulk_trash skips already-trashed rows (count reflects only newly-trashed)", ctx do
+      [r1 | rest] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids = [r1.uuid | Enum.map(rest, & &1.uuid)]
+      assert {2, _} = EntityData.bulk_trash(uuids)
+    end
+
+    test "bulk_restore_from_trash flips trashed→published and logs ONE summary row", ctx do
+      uuids = Enum.map(ctx.records, & &1.uuid)
+      {3, _} = EntityData.bulk_trash(uuids, actor_uuid: ctx.actor_uuid)
+
+      assert {3, _} = EntityData.bulk_restore_from_trash(uuids, actor_uuid: ctx.actor_uuid)
+
+      assert_activity_logged("entity_data.bulk_restored",
+        actor_uuid: ctx.actor_uuid,
+        metadata_has: %{"count" => 3, "uuid_count" => 3}
+      )
+
+      Enum.each(uuids, fn uuid ->
+        assert EntityData.get(uuid).status == "published"
+      end)
+    end
+
+    test "bulk_restore_from_trash only touches trashed rows", ctx do
+      [r1, _r2, _r3] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids = Enum.map(ctx.records, & &1.uuid)
+      assert {1, _} = EntityData.bulk_restore_from_trash(uuids)
+    end
+
+    test "bulk_trash with empty list returns {0, _} and logs zero-count row", ctx do
+      assert {0, _} = EntityData.bulk_trash([], actor_uuid: ctx.actor_uuid)
+
+      assert_activity_logged("entity_data.bulk_trashed",
+        actor_uuid: ctx.actor_uuid,
+        metadata_has: %{"count" => 0, "uuid_count" => 0}
+      )
+    end
+
+    test "bulk_restore_from_trash with empty list returns {0, _}", ctx do
+      assert {0, _} = EntityData.bulk_restore_from_trash([], actor_uuid: ctx.actor_uuid)
+    end
+
+    test "bulk_trash broadcasts a data_updated event per affected entity", ctx do
+      uuids = Enum.map(ctx.records, & &1.uuid)
+      Events.subscribe_to_entity_data(ctx.entity.uuid)
+
+      {3, _} = EntityData.bulk_trash(uuids)
+
+      # We seeded 3 records on the same entity; expect 3 broadcasts.
+      received =
+        for _ <- 1..3 do
+          assert_receive {:data_updated, _, uuid}, 1_000
+          uuid
+        end
+
+      assert Enum.sort(received) == Enum.sort(uuids)
+    end
+  end
+
+  describe "delete/2 — friendly Postgrex error" do
+    test "succeeds when no parent rows reference the record", ctx do
+      [record | _] = ctx.records
+      assert {:ok, %EntityData{}} = EntityData.delete(record, actor_uuid: ctx.actor_uuid)
+      refute EntityData.get(record.uuid)
+    end
+
+    test "returns :referenced_by_external when a parent FK violation occurs", ctx do
+      # Simulate a parent app with a NOT NULL FK to phoenix_kit_entity_data.uuid:
+      # set up a transient table within the sandbox transaction. This is the
+      # exact shape the issue #12 author hit in their orders table.
+      [record | _] = ctx.records
+
+      SQL.query!(repo(), """
+      CREATE TABLE _trash_test_parent (
+        id serial primary key,
+        status_uuid uuid NOT NULL REFERENCES phoenix_kit_entity_data(uuid) ON DELETE RESTRICT
+      )
+      """)
+
+      SQL.query!(
+        repo(),
+        """
+        INSERT INTO _trash_test_parent (status_uuid) VALUES ($1)
+        """,
+        [UUID.dump!(record.uuid)]
+      )
+
+      assert {:error, :referenced_by_external} =
+               EntityData.delete(record, actor_uuid: ctx.actor_uuid)
+
+      # Row stays in DB — soft-delete fallback path.
+      assert %EntityData{} = EntityData.get(record.uuid)
+    end
+
+    test "bulk_delete returns :referenced_by_external on FK violation, no rows deleted", ctx do
+      [record | _] = ctx.records
+
+      SQL.query!(repo(), """
+      CREATE TABLE _trash_test_parent_bulk (
+        id serial primary key,
+        status_uuid uuid NOT NULL REFERENCES phoenix_kit_entity_data(uuid) ON DELETE RESTRICT
+      )
+      """)
+
+      SQL.query!(
+        repo(),
+        """
+        INSERT INTO _trash_test_parent_bulk (status_uuid) VALUES ($1)
+        """,
+        [UUID.dump!(record.uuid)]
+      )
+
+      uuids = Enum.map(ctx.records, & &1.uuid)
+      assert {:error, :referenced_by_external} = EntityData.bulk_delete(uuids)
+
+      # Transaction rolled back — every record still exists.
+      Enum.each(uuids, fn uuid ->
+        assert %EntityData{} = EntityData.get(uuid)
+      end)
+    end
+
+    test "delete/2 surfaces NOT NULL violation as :referenced_by_external (issue #12 case)",
+         ctx do
+      # Issue #12's documented setup: parent column NOT NULL with
+      # `on_delete: :nilify_all`. PostgreSQL fires the on_delete action
+      # (sets status_uuid to NULL), which then violates the NOT NULL
+      # constraint, raising SQLSTATE 23502.
+      [record | _] = ctx.records
+
+      SQL.query!(repo(), """
+      CREATE TABLE _trash_test_nilify_parent (
+        id serial primary key,
+        status_uuid uuid NOT NULL REFERENCES phoenix_kit_entity_data(uuid) ON DELETE SET NULL
+      )
+      """)
+
+      SQL.query!(
+        repo(),
+        "INSERT INTO _trash_test_nilify_parent (status_uuid) VALUES ($1)",
+        [UUID.dump!(record.uuid)]
+      )
+
+      assert {:error, :referenced_by_external} =
+               EntityData.delete(record, actor_uuid: ctx.actor_uuid)
+
+      assert %EntityData{} = EntityData.get(record.uuid)
+    end
+
+    test "delete/2 logs error activity row (db_pending: true) on FK violation", ctx do
+      [record | _] = ctx.records
+
+      SQL.query!(repo(), """
+      CREATE TABLE _trash_test_audit_parent (
+        id serial primary key,
+        status_uuid uuid NOT NULL REFERENCES phoenix_kit_entity_data(uuid) ON DELETE RESTRICT
+      )
+      """)
+
+      SQL.query!(
+        repo(),
+        "INSERT INTO _trash_test_audit_parent (status_uuid) VALUES ($1)",
+        [UUID.dump!(record.uuid)]
+      )
+
+      {:error, :referenced_by_external} =
+        EntityData.delete(record, actor_uuid: ctx.actor_uuid)
+
+      assert_activity_logged("entity_data.deleted",
+        actor_uuid: ctx.actor_uuid,
+        metadata_has: %{"db_pending" => true}
+      )
+    end
+  end
+
+  describe "default-list filtering" do
+    test "list_all excludes trashed", ctx do
+      [r1 | _] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids = Enum.map(EntityData.list_all(), & &1.uuid)
+      refute r1.uuid in uuids
+    end
+
+    test "search_by_title excludes trashed", ctx do
+      [r1 | _] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids =
+        EntityData.search_by_title("Record", ctx.entity.uuid)
+        |> Enum.map(& &1.uuid)
+
+      refute r1.uuid in uuids
+    end
+
+    test "filter_by_status('trashed') returns only trashed", ctx do
+      [r1 | _] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids =
+        EntityData.filter_by_status("trashed")
+        |> Enum.map(& &1.uuid)
+
+      assert r1.uuid in uuids
+    end
+
+    test "get_by_slug still finds trashed records (slug uniqueness preserved)", ctx do
+      [r1 | _] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      assert %EntityData{uuid: same_uuid} = EntityData.get_by_slug(ctx.entity.uuid, r1.slug)
+      assert same_uuid == r1.uuid
+    end
+
+    test "list_all with include_trashed: true returns trashed records too", ctx do
+      [r1 | _] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids = Enum.map(EntityData.list_all(include_trashed: true), & &1.uuid)
+      assert r1.uuid in uuids
+    end
+
+    test "search_by_title with include_trashed: true returns trashed", ctx do
+      [r1 | _] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids =
+        EntityData.search_by_title("Record", ctx.entity.uuid, include_trashed: true)
+        |> Enum.map(& &1.uuid)
+
+      assert r1.uuid in uuids
+    end
+
+    test "list_by_entity_and_status('published') doesn't leak trashed", ctx do
+      [r1 | _] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids =
+        EntityData.list_by_entity_and_status(ctx.entity.uuid, "published")
+        |> Enum.map(& &1.uuid)
+
+      refute r1.uuid in uuids
+    end
+
+    test "list_by_entity_and_status('trashed') returns only trashed", ctx do
+      [r1, _r2, _r3] = ctx.records
+      {:ok, _} = EntityData.trash(r1)
+
+      uuids =
+        EntityData.list_by_entity_and_status(ctx.entity.uuid, "trashed")
+        |> Enum.map(& &1.uuid)
+
+      assert uuids == [r1.uuid]
+    end
+
+    test "filter_by_status('archived') doesn't leak trashed records", ctx do
+      [r1, r2 | _] = ctx.records
+      {:ok, _} = EntityData.update(r1, %{status: "archived"})
+      {:ok, _} = EntityData.trash(r2)
+
+      uuids =
+        EntityData.filter_by_status("archived")
+        |> Enum.map(& &1.uuid)
+
+      assert r1.uuid in uuids
+      refute r2.uuid in uuids
+    end
+  end
+
+  describe "count_external_references/1" do
+    test "returns 0 when no callbacks are registered", ctx do
+      [record | _] = ctx.records
+      Application.delete_env(:phoenix_kit_entities, :reverse_references)
+
+      assert EntityData.count_external_references(record) == 0
+    end
+
+    test "sums counts across registered callbacks for the matching entity name", ctx do
+      [record | _] = ctx.records
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"trash_test", fn _uuid -> 7 end},
+        {"trash_test", fn _uuid -> 3 end},
+        {"other_entity", fn _uuid -> 100 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      assert EntityData.count_external_references(record) == 10
+    end
+
+    test "ignores callbacks that raise", ctx do
+      [record | _] = ctx.records
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"trash_test", fn _uuid -> raise "boom" end},
+        {"trash_test", fn _uuid -> 5 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      assert EntityData.count_external_references(record) == 5
+    end
+
+    test "ignores callbacks returning negative integers", ctx do
+      [record | _] = ctx.records
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"trash_test", fn _uuid -> -10 end},
+        {"trash_test", fn _uuid -> 4 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      assert EntityData.count_external_references(record) == 4
+    end
+
+    test "ignores callbacks returning non-integers", ctx do
+      [record | _] = ctx.records
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"trash_test", fn _uuid -> "lots" end},
+        {"trash_test", fn _uuid -> :many end},
+        {"trash_test", fn _uuid -> 7 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      assert EntityData.count_external_references(record) == 7
+    end
+
+    test "ignores entries that aren't {name, fun-of-arity-1}", ctx do
+      [record | _] = ctx.records
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        # not arity 1
+        {"trash_test", fn -> 99 end},
+        # not a {name, fun} tuple
+        :garbage,
+        {"trash_test", "not a function"},
+        {"trash_test", fn _uuid -> 3 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      assert EntityData.count_external_references(record) == 3
+    end
+
+    test "skips callbacks bound to a different entity name", ctx do
+      [record | _] = ctx.records
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"some_other_entity", fn _uuid -> 1000 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      assert EntityData.count_external_references(record) == 0
+    end
+
+    test "returns 0 when the entity association doesn't resolve" do
+      # Synthetic struct whose entity_uuid points nowhere — the preload
+      # comes back with entity: nil and the catchall branch returns 0.
+      # This is reachable in practice if a parent app constructs a record
+      # in-memory before the entity row exists, or after a forced delete.
+      orphan = %EntityData{
+        uuid: UUID.generate(),
+        entity_uuid: UUID.generate()
+      }
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"trash_test", fn _uuid -> 99 end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      assert EntityData.count_external_references(orphan) == 0
+    end
+  end
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
+end

--- a/test/phoenix_kit_entities/errors_test.exs
+++ b/test/phoenix_kit_entities/errors_test.exs
@@ -27,6 +27,20 @@ defmodule PhoenixKitEntities.ErrorsTest do
     test ":unexpected" do
       assert Errors.message(:unexpected) == "An unexpected error occurred."
     end
+
+    test ":already_trashed" do
+      assert Errors.message(:already_trashed) == "This record is already in the trash."
+    end
+
+    test ":not_trashed" do
+      assert Errors.message(:not_trashed) == "This record is not in the trash."
+    end
+
+    test ":referenced_by_external surfaces a friendly explanation of the FK violation" do
+      msg = Errors.message(:referenced_by_external)
+      assert msg =~ "Cannot permanently delete"
+      assert msg =~ "referenced by other tables"
+    end
   end
 
   describe "message/1 tagged tuples" do

--- a/test/phoenix_kit_entities/mirror/exporter_test.exs
+++ b/test/phoenix_kit_entities/mirror/exporter_test.exs
@@ -129,6 +129,48 @@ defmodule PhoenixKitEntities.Mirror.ExporterTest do
       assert {:error, :entity_not_found} =
                Exporter.export_entity("unknown_#{System.unique_integer([:positive])}")
     end
+
+    test "trashed records are excluded from the data array (issue #12)", ctx do
+      # Add a second record then trash the original. The exporter pulls
+      # data via EntityData.list_data_by_entity/2, which excludes trashed
+      # by default. The exported JSON's "data" array must NOT contain the
+      # trashed record's title — otherwise mirror imports would resurrect
+      # soft-deleted rows.
+      Storage.enable_data()
+
+      # Enable per-entity mirror_data so include_data is true in the exporter.
+      {:ok, entity_with_mirror} =
+        Entities.update_mirror_settings(ctx.entity, %{"mirror_data" => true})
+
+      {:ok, _live_record} =
+        EntityData.create(
+          %{
+            entity_uuid: ctx.entity.uuid,
+            title: "Live record",
+            slug: "live",
+            status: "published",
+            data: %{"title" => "Live"},
+            created_by_uuid: ctx.actor_uuid
+          },
+          actor_uuid: ctx.actor_uuid
+        )
+
+      {:ok, _} = EntityData.trash(ctx.record, actor_uuid: ctx.actor_uuid)
+
+      case Exporter.export_entity(entity_with_mirror) do
+        {:ok, file_path, _mode} ->
+          %{"data" => data} = file_path |> File.read!() |> Jason.decode!()
+          titles = Enum.map(data, & &1["title"])
+
+          assert "Live record" in titles
+          refute ctx.record.title in titles
+
+        {:error, _} ->
+          # Storage containment may reject the tmp path; skip but the
+          # context fn still ran with the trashed-row exclusion.
+          :skipped
+      end
+    end
   end
 
   describe "export_entity_data/1" do

--- a/test/phoenix_kit_entities/web/data_navigator_live_test.exs
+++ b/test/phoenix_kit_entities/web/data_navigator_live_test.exs
@@ -1,11 +1,13 @@
 defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
   use PhoenixKitEntities.LiveCase, async: false
 
+  alias Ecto.Adapters.SQL
+  alias Ecto.UUID
   alias PhoenixKitEntities, as: Entities
   alias PhoenixKitEntities.EntityData
 
   setup do
-    actor_uuid = Ecto.UUID.generate()
+    actor_uuid = UUID.generate()
 
     {:ok, entity} =
       Entities.create_entity(
@@ -135,7 +137,10 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
       )
     end
 
-    test "bulk delete logs ONE bulk_deleted row", %{conn: conn} = ctx do
+    test "bulk delete (soft) logs ONE bulk_trashed row", %{conn: conn} = ctx do
+      # The "delete" bulk action is now a soft-delete (trash) — the row stays
+      # alive so parent-app FK references resolve. Hard-delete moved to the
+      # "permanent_delete" action, available from the Trash filter view.
       conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
       {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
 
@@ -145,7 +150,7 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
 
       render_hook(view, "bulk_action", %{"action" => "delete"})
 
-      assert_activity_logged("entity_data.bulk_deleted",
+      assert_activity_logged("entity_data.bulk_trashed",
         actor_uuid: ctx.actor_uuid,
         metadata_has: %{"count" => 3, "uuid_count" => 3}
       )
@@ -377,6 +382,320 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
     end
   end
 
+  describe "trash_data / restore_from_trash / permanent_delete (issue #12)" do
+    test "trash_data soft-deletes — row stays alive, status flips to trashed",
+         %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
+
+      render_hook(view, "trash_data", %{"uuid" => record.uuid})
+
+      assert_activity_logged("entity_data.trashed",
+        actor_uuid: ctx.actor_uuid,
+        resource_uuid: record.uuid
+      )
+
+      assert render(view) =~ "moved to trash"
+      assert EntityData.get(record.uuid).status == "trashed"
+    end
+
+    test "restore_from_trash flips trashed → published",
+         %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "restore_from_trash", %{"uuid" => record.uuid})
+
+      assert_activity_logged("entity_data.restored",
+        actor_uuid: ctx.actor_uuid,
+        resource_uuid: record.uuid
+      )
+
+      assert render(view) =~ "restored from trash"
+      assert EntityData.get(record.uuid).status == "published"
+    end
+
+    test "permanent_delete hard-deletes when no parent FK references", %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "permanent_delete", %{"uuid" => record.uuid})
+
+      assert render(view) =~ "permanently deleted"
+      refute EntityData.get(record.uuid)
+    end
+
+    test "permanent_delete flashes a friendly message on FK violation, row stays",
+         %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      SQL.query!(repo(), """
+      CREATE TABLE _dn_test_parent (
+        id serial primary key,
+        status_uuid uuid NOT NULL REFERENCES phoenix_kit_entity_data(uuid) ON DELETE RESTRICT
+      )
+      """)
+
+      SQL.query!(
+        repo(),
+        "INSERT INTO _dn_test_parent (status_uuid) VALUES ($1)",
+        [UUID.dump!(record.uuid)]
+      )
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "permanent_delete", %{"uuid" => record.uuid})
+
+      assert render(view) =~ "referenced by other tables"
+      # Row still exists — soft-delete fallback path.
+      assert %EntityData{status: "trashed"} = EntityData.get(record.uuid)
+    end
+
+    test "bulk_action 'permanent_delete' hard-deletes selected trashed records",
+         %{conn: conn} = ctx do
+      [r1, r2, _r3] = ctx.records
+      {:ok, _} = EntityData.trash(r1, actor_uuid: ctx.actor_uuid)
+      {:ok, _} = EntityData.trash(r2, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "toggle_select", %{"uuid" => r1.uuid})
+      render_hook(view, "toggle_select", %{"uuid" => r2.uuid})
+      render_hook(view, "bulk_action", %{"action" => "permanent_delete"})
+
+      assert render(view) =~ "permanently deleted"
+      refute EntityData.get(r1.uuid)
+      refute EntityData.get(r2.uuid)
+    end
+
+    test "bulk_action 'restore_from_trash' flips selected trashed → published",
+         %{conn: conn} = ctx do
+      [r1, r2, _] = ctx.records
+      {:ok, _} = EntityData.trash(r1, actor_uuid: ctx.actor_uuid)
+      {:ok, _} = EntityData.trash(r2, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "toggle_select", %{"uuid" => r1.uuid})
+      render_hook(view, "toggle_select", %{"uuid" => r2.uuid})
+      render_hook(view, "bulk_action", %{"action" => "restore_from_trash"})
+
+      assert_activity_logged("entity_data.bulk_restored",
+        actor_uuid: ctx.actor_uuid,
+        metadata_has: %{"count" => 2}
+      )
+
+      assert render(view) =~ "restored from trash"
+      assert EntityData.get(r1.uuid).status == "published"
+      assert EntityData.get(r2.uuid).status == "published"
+    end
+
+    test "trash_data on already-trashed record shows :info flash, not error",
+         %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "trash_data", %{"uuid" => record.uuid})
+      assert render(view) =~ "already in the trash"
+    end
+
+    test "restore_from_trash on non-trashed record shows :info flash",
+         %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
+
+      render_hook(view, "restore_from_trash", %{"uuid" => record.uuid})
+      assert render(view) =~ "not in the trash"
+    end
+
+    test "trash_data refused for non-admin scope", %{conn: conn} = ctx do
+      [record | _] = ctx.records
+
+      conn =
+        put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid, roles: [], permissions: []))
+
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
+
+      render_hook(view, "trash_data", %{"uuid" => record.uuid})
+
+      assert render(view) =~ "Not authorized"
+      # Row unchanged.
+      assert EntityData.get(record.uuid).status == "published"
+    end
+
+    test "restore_from_trash refused for non-admin scope", %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      conn =
+        put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid, roles: [], permissions: []))
+
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "restore_from_trash", %{"uuid" => record.uuid})
+
+      assert render(view) =~ "Not authorized"
+      assert EntityData.get(record.uuid).status == "trashed"
+    end
+
+    test "permanent_delete refused for non-admin scope", %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      conn =
+        put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid, roles: [], permissions: []))
+
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "permanent_delete", %{"uuid" => record.uuid})
+
+      assert render(view) =~ "Not authorized"
+      assert %EntityData{} = EntityData.get(record.uuid)
+    end
+
+    test "bulk_action 'permanent_delete' with empty selection flashes error",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "bulk_action", %{"action" => "permanent_delete"})
+
+      assert render(view) =~ "No records selected"
+    end
+
+    test "bulk_action 'restore_from_trash' with empty selection flashes error",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "bulk_action", %{"action" => "restore_from_trash"})
+
+      assert render(view) =~ "No records selected"
+    end
+
+    test "bulk_action 'trash' with empty selection flashes error",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
+
+      render_hook(view, "bulk_action", %{"action" => "trash"})
+
+      assert render(view) =~ "No records selected"
+    end
+
+    test "bulk_action 'permanent_delete' refused for non-admin scope",
+         %{conn: conn} = ctx do
+      conn =
+        put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid, roles: [], permissions: []))
+
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "bulk_action", %{"action" => "permanent_delete"})
+
+      assert render(view) =~ "Not authorized"
+    end
+
+    test "Trash filter option appears in status dropdown (UI structure)",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, _view, html} = live(conn, navigator_url(ctx.entity))
+
+      assert html =~ ~s(<option value="trashed")
+      assert html =~ "Trash"
+    end
+
+    test "Trash filter option shows count badge when trashed_records > 0",
+         %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, _view, html} = live(conn, navigator_url(ctx.entity))
+
+      # The dropdown option text includes "(N)" when trashed_records is non-zero.
+      assert html =~ ~r/Trash\s*\(1\)/
+    end
+
+    test "viewing the Trash filter shows Restore + Delete-forever bulk buttons",
+         %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      # Select the trashed row so the bulk bar renders.
+      render_hook(view, "toggle_select", %{"uuid" => record.uuid})
+      html = render(view)
+
+      assert html =~ ~s(phx-value-action="restore_from_trash")
+      assert html =~ ~s(phx-value-action="permanent_delete")
+      # The non-trash views' Trash button should NOT appear.
+      refute html =~ ~s(phx-value-action="trash")
+    end
+
+    test "non-trash view's bulk bar shows Trash but NOT Permanent-delete",
+         %{conn: conn} = ctx do
+      [record | _] = ctx.records
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
+
+      render_hook(view, "toggle_select", %{"uuid" => record.uuid})
+      html = render(view)
+
+      assert html =~ ~s(phx-value-action="trash")
+      refute html =~ ~s(phx-value-action="permanent_delete")
+      refute html =~ ~s(phx-value-action="restore_from_trash")
+    end
+  end
+
+  describe "status helpers (status_badge_class / status_label / status_icon)" do
+    alias PhoenixKitEntities.Web.DataNavigator
+
+    test "trashed sentinel renders as the error badge with the trash icon" do
+      assert DataNavigator.status_badge_class("trashed") == "badge-error"
+      assert DataNavigator.status_icon("trashed") == "hero-trash"
+      assert DataNavigator.status_label("trashed") == "Trashed"
+    end
+
+    test "existing statuses still resolve" do
+      assert DataNavigator.status_badge_class("published") == "badge-success"
+      assert DataNavigator.status_badge_class("draft") == "badge-warning"
+      assert DataNavigator.status_badge_class("archived") == "badge-neutral"
+    end
+  end
+
+  describe "toggle_status preserves trashed status (does NOT cycle to published)" do
+    test "toggle_status on a trashed record is a no-op", %{conn: conn} = ctx do
+      [record | _] = ctx.records
+      {:ok, _} = EntityData.trash(record, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "toggle_status", %{"uuid" => record.uuid})
+
+      # Status MUST NOT cycle out of trashed. Restore is the only escape.
+      assert EntityData.get(record.uuid).status == "trashed"
+    end
+  end
+
   describe "reorder_records (drag-and-drop)" do
     test "reorders records and refreshes the list",
          %{conn: conn} = ctx do
@@ -440,4 +759,6 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
       status -> base <> "?status=#{status}"
     end
   end
+
+  defp repo, do: PhoenixKit.RepoHelper.repo()
 end

--- a/test/phoenix_kit_entities/web/data_navigator_live_test.exs
+++ b/test/phoenix_kit_entities/web/data_navigator_live_test.exs
@@ -430,6 +430,13 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
 
       assert render(view) =~ "permanently deleted"
       refute EntityData.get(record.uuid)
+
+      # Pin the audit row — without this, the LV could silently drop
+      # actor_uuid and the test would still pass on flash + DB state.
+      assert_activity_logged("entity_data.deleted",
+        actor_uuid: ctx.actor_uuid,
+        resource_uuid: record.uuid
+      )
     end
 
     test "permanent_delete flashes a friendly message on FK violation, row stays",
@@ -458,6 +465,14 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
       assert render(view) =~ "referenced by other tables"
       # Row still exists — soft-delete fallback path.
       assert %EntityData{status: "trashed"} = EntityData.get(record.uuid)
+
+      # Pin the audit row — `db_pending: true` flags the user-initiated
+      # action that the DB rolled back. Without this assertion the LV
+      # could silently drop actor_uuid on the error path.
+      assert_activity_logged("entity_data.deleted",
+        actor_uuid: ctx.actor_uuid,
+        metadata_has: %{"db_pending" => true}
+      )
     end
 
     test "bulk_action 'permanent_delete' hard-deletes selected trashed records",


### PR DESCRIPTION
## Summary

Closes #12. Parent apps that hold FK references to `phoenix_kit_entity_data` (controlled vocabularies — `orders.status_uuid`, etc.) hit opaque 500s when an admin clicks Delete on a referenced record. Soft-delete via the existing `status` column with sentinel `"trashed"` keeps the row alive so parent FKs stay satisfied; the admin gets a Trash filter view with Restore + Delete-forever actions; hard-delete catches FK / NOT NULL violations and surfaces a friendly flash via a new `:referenced_by_external` Errors atom.

This is the **soft-delete reframe** of issue #12's option 2 (the author proposed a new `deleted_at` column; that would have been inconsistent with the workspace-wide `status`-string convention — see `phoenix_kit_publishing` posts and `phoenix_kit_catalogue` items for precedent). No new column, no new core migration.

### Soft-delete (commit `0cf10fc`)

- `EntityData.trash/2`, `restore_from_trash/2`, `bulk_trash/2`, `bulk_restore_from_trash/2`, `list_trashed_by_entity/2`, `trashed_count/1`
- `delete/2` and `bulk_delete/2` now rescue `Ecto.ConstraintError` (per-record path) and `Postgrex.Error` SQLSTATE `23503/23502` (bulk path), returning `{:error, :referenced_by_external}` so the LV flashes a friendly message
- New error atoms: `:already_trashed`, `:not_trashed`, `:referenced_by_external`
- DataNavigator bulk Delete repurposed → soft-trash; permanent delete is a separate action available only from the Trash filter view
- New per-record buttons branch by status: published/draft → Archive + Trash, archived → Restore + Trash, trashed → Restore-from-trash + Delete-forever
- `toggle_status` cycle skips trashed (Restore is the only escape)
- Default-list queries (`list_all`, `list_by_entity`, `search_by_title`, `count_by_entity`) exclude trashed; `include_trashed: true` opt for admin/reverse-ref paths
- `get_data_stats/1` exposes `trashed_records`; `total_records` excludes trashed (visible-total semantics)
- Mirror exporter naturally excludes trashed (default `list_data_by_entity` filter) — exports won't resurrect soft-deleted rows
- `count_external_references/1` reads `Application.get_env(:reverse_references, [])` — list of `{entity_name, count_fn}` tuples for parent apps to declare cross-DB reference counts. Informational only, not a delete-blocker.

### Phase 2 quality sweep (commits `574a809`, `99ed89c`, `2233ab3`)

C12 + C12.5 follow-up against the soft-delete branch.

**Quality sweep deltas:**

- **`@spec` coverage** — `list_trashed_by_entity/2` and `trashed_count/1` had `@doc` but no `@spec`; added.
- **`phx-disable-with` on bulk action bar** — all 8 bulk_action buttons (Archive, Restore, Trash, Restore-from-trash, Permanent-delete, 3× Change-status) were missing it. 3 from the soft-delete additions inheriting the pre-existing oversight on the 5 originals; added across all 8.
- **Test coverage gaps** — `permanent_delete` LV happy-path test now pins `entity_data.deleted` activity row with `actor_uuid` + `resource_uuid`; `bulk_delete` FK-error test now pins `db_pending: true` audit row.
- **Pre-existing rescue cleanups** (`99ed89c`):
  - `controllers/entity_form_controller.ex:495` — `private_or_local_ip?/1` swapped from `String.to_integer + rescue _` to `Integer.parse/1` with explicit `with`/`else` chain. No rescue clause needed; failure mode visible in the source.
  - `sitemap_source.ex:140` — `sub_sitemaps/1`'s `rescue _ -> nil` now logs `Sitemap: failed to build sub_sitemaps for entities: <inspect>` matching the pattern at the other two rescues in the file.
  - `sitemap_source.ex:148` — `enabled?/0` gained `catch :exit, _ -> false` matching the canonical shape in `phoenix_kit_entities.ex` for sandbox-shutdown signals.
- **N+1 fix on `count_external_references`** (`2233ab3`) — quorum review (5 AIs, 5/5 agreed config-list shape was right but flagged the per-call `repo().preload`). Added a 2-arity form `count_external_references/2(record, entity)` so callers rendering many records (admin trash bin, list views) can load the entity once and skip the per-call hit. Internal dispatch goes through a private helper to avoid a recursion trap on orphan records.
- **AGENTS.md** gained a "Soft-delete (trash) for EntityData" section under Architecture covering the why (parent-app FK targets), public API, default-list filtering rules, slug uniqueness rationale, the `:reverse_references` config hook, and the admin DataNavigator UX changes. Action-atom convention list extended with `trashed`/`restored`/`bulk_trashed`/`bulk_restored`.

### Tests

Net +130 tests (645 → 775). New `entity_data_trash_test.exs` (49 tests) covers trash/restore/bulk variants with activity-log pinning + PubSub broadcast assertions + FK-violation paths using transient `_trash_test_parent` tables that mirror issue #12's exact NOT-NULL+`:nilify_all` shape. New describe block in `data_navigator_live_test.exs` (18 tests) covers all event handlers + authorization + empty-selection + UI structure (Trash filter option, count badge, bulk action bar branching). Errors test gained 3 atom assertions. Mirror exporter test pins trashed-record exclusion.

## Verification

- `mix compile --warnings-as-errors` clean
- `mix format --check-formatted` clean
- `mix credo --strict` — 1103 mods/funs, no issues
- `mix test` — 775 tests, 0 failures
- 5× stability runs clean
- Stale-ref grep clean (no `IO.inspect` / `IO.puts` / TODO / FIXME / Gettext.gettext / String.capitalize / commented-out code in `lib/`)
- ast-grep clean (no `Task.start`, no blanket `rescue _ -> $_` outside the documented defensive shapes)
- Browser smoke-check on `phoenix_kit_parent` dev server: trash → restore → permanent-delete loop verified end-to-end with stats card updates, Trash filter count badge, bulk-bar branching by view, and `phx-disable-with="…"` rendering on all 6 bulk_action buttons in the live HTML

## Test plan

- [x] `mix test` 775/775
- [x] 5/5 stability runs
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` clean
- [x] `mix compile --warnings-as-errors` clean
- [x] Browser smoke-check (trash → restore → permanent-delete + bulk variants)
- [x] FK-violation friendly flash verified via integration test using a transient parent table with `NOT NULL REFERENCES … ON DELETE RESTRICT`
- [x] Mirror exporter excludes trashed records (test `trashed records are excluded from the data array (issue #12)`)
- [x] Slug uniqueness preserved on `get_by_slug` (test `get_by_slug still finds trashed records (slug uniqueness preserved)`)