### PR TITLE
Migration cleanup: swap test_helper to PhoenixKit.Migration.ensure_current/2

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -61,7 +61,15 @@ repo_available =
       # call the host app makes in production. The entities tables come from
       # core (V17 creates them; V40/V58/V67/V74/V81 evolve them). No
       # module-owned DDL anywhere.
-      Ecto.Migrator.run(TestRepo, [{0, PhoenixKit.Migration}], :up, all: true, log: false)
+      #
+      # `ensure_current/2` (core 1.7.105+ / phoenix_kit#515) re-applies
+      # any newly-shipped Vxxx migrations on every boot by passing a
+      # fresh wall-clock version to Ecto.Migrator. Replaces the
+      # `Ecto.Migrator.run([{0, PhoenixKit.Migration}], :up, all: true)`
+      # pattern, which silently stopped re-applying once `0` was
+      # recorded in `schema_migrations` — see
+      # `dev_docs/migration_cleanup.md` for the staleness story.
+      PhoenixKit.Migration.ensure_current(TestRepo, log: false)
 
       Ecto.Adapters.SQL.Sandbox.mode(TestRepo, :manual)
 


### PR DESCRIPTION
## Summary

Swap `test/test_helper.exs` from `Ecto.Migrator.run([{0, PhoenixKit.Migration}], :up, all: true)` to `PhoenixKit.Migration.ensure_current/2` (core 1.7.105+).

The deprecated pattern is idempotent at the outer Ecto.Migrator layer — once `0` is recorded in `schema_migrations`, the inner runner is never re-invoked, so newly-shipped Vxxx migrations silently never apply. `ensure_current/2` sidesteps this by passing a fresh wall-clock version on each call (PhoenixKit's own marker short-circuits when there's nothing new). See `dev_docs/migration_cleanup.md` for the full staleness story.

**Should be merged after BeamLabEU/phoenix_kit#515** — CI will be red until core 1.7.105 publishes (the `ensure_current/2` function ships in that release).

## Verification

Local test suite via `phoenix_kit_parent` path-dep override resolving to local core 1.7.104+:

- `mix test` — 775 tests, 0 failures
- 3 consecutive stable runs

## Test plan

- [x] `mix test` — 775 tests, 0 failures
- [x] 3 consecutive stable runs
- [ ] CI greens after core 1.7.105 publishes