### PR TITLE
Phase 2 re-validation + parent_uuid + Create-and-Return + dropdowns + DnD handle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,14 @@ referencing the same `order_status` add together). Informational
 only, **NOT a delete-blocker** — soft-delete is safe regardless of
 the count.
 
+The `:reverse_references` key lives in the **global** OTP application
+env, so in an umbrella where two parent apps both define a callback
+for the same entity name (e.g. both register `"order_status"`), both
+callbacks fire on every `count_external_references/1` call and the
+totals add. For a single-tenant deploy this is irrelevant; multi-
+tenant hosts should pick distinct entity names per app or accept
+the cross-pollination.
+
 The 1-arity form preloads `:entity` per call. When rendering many
 records (admin trash bin, list views), prefer the 2-arity form
 `count_external_references(record, entity)` and load the entity

--- a/dev_docs/pull_requests/2026/13-soft-delete-issue-12/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/13-soft-delete-issue-12/FOLLOW_UP.md
@@ -1,0 +1,129 @@
+---
+name: PR #13 follow-up — soft-delete review actions
+description: Resolution of every CLAUDE_REVIEW.md finding for PR #13.
+type: project
+---
+
+# PR #13 Follow-up — Soft-delete for EntityData
+
+**Review:** [`CLAUDE_REVIEW.md`](./CLAUDE_REVIEW.md) (Claude Opus 4.7, 2026-05-04)
+**Triage:** 2026-05-12
+
+The post-merge review surfaced 9 non-blocking findings (1 MEDIUM, 4 LOW,
+3 TRIVIAL/NIT). All 9 were verified live against `main` and fixed in
+this batch.
+
+## Fixed (Batch 1 — 2026-05-12)
+
+- ~~**F1 (MEDIUM)** — `trash/2` and `restore_from_trash/2` ran the full
+  per-field validation against the entity blueprint, blocking trash on
+  records whose stored `:data` no longer satisfied the current
+  `fields_definition` (e.g. the entity gained a required field after
+  the row was created). Replaced both call sites with a focused
+  `status_only_changeset/3` that only casts `:status`, `:metadata`,
+  `:date_updated` and `validate_inclusion(:status, @valid_statuses)`.
+  Mirrors the bulk variants' bypass-validation semantics so single +
+  bulk paths agree.~~ — `entity_data.ex:1379-1413`
+- ~~**F2 (LOW)** — `restore_from_trash/2` always returned to
+  `"published"`, silently re-publishing a record that was `"draft"` or
+  `"archived"` before being trashed. `trash/2` now stashes the row's
+  prior `status` into `metadata["trashed_from_status"]`;
+  `restore_from_trash/2` reads it back and restores to that value,
+  defaulting to `"draft"` when absent. The stash key is dropped on
+  restore so the metadata stays clean for any future re-trash. Bulk
+  paths are unchanged (atomic `update_all`, no per-row metadata); a
+  bulk-trashed-then-restored row picks the `"draft"` default — matches
+  the review's safer-by-default recommendation.~~ — `entity_data.ex:1379-1413`
+- ~~**F3 (LOW)** — `do_count_external_references/2` had a blanket
+  `rescue _ -> acc` that swallowed every callback exception, including
+  bugs in the parent-app callback itself. A broken callback silently
+  reported "Used by 0 rows" with no log signal. Narrowed to
+  `rescue e in [DBConnection.ConnectionError, Postgrex.Error]` with a
+  `Logger.warning` on the caught shape; any other raise now propagates
+  (consistent with `99ed89c`'s narrowing of the other broad rescues in
+  this PR). Test updated: replaced the "ignores callbacks that raise"
+  test (which pinned the old buggy contract) with two pinning tests —
+  one asserts DB-availability raises are swallowed + logged, the
+  other asserts non-DB raises propagate.~~ —
+  `entity_data.ex:1882-1898`, `entity_data_trash_test.exs:568-602`
+- ~~**F4 (TRIVIAL)** — `toggle_status` had a dead
+  `"trashed" -> "trashed"` clause; the UI hides the toggle button for
+  trashed rows so it was unreachable in practice but, if hit (stale
+  tab / custom client), `update_data` would no-op and the cycle would
+  silently swallow the click. Swapped to a catch-all `_ ->
+  data_record.status` with a code comment naming the unreachability +
+  the intentional no-op semantic.~~ — `data_navigator.ex:384-396`
+- ~~**F5 (LOW)** — Docstring on `count_external_references/2`
+  advertised an "admin trash bin" use case, but no LV call site in
+  `lib/phoenix_kit_entities/web/` actually renders the count. Rewrote
+  the example to frame it as the parent-app-consumption API that it
+  is. The 2-arity form's N+1 fix stays in place as future-proofing.~~
+  — `entity_data.ex:1790-1794`
+- ~~**F6 (TRIVIAL)** — `permanent_delete` (single) and
+  `do_bulk_permanent_delete/1` both leave their respective selections
+  populated on the `:referenced_by_external` branch — intentional, so
+  the user can fix references in the parent app and retry without
+  re-checking each row. Added an inline comment on both call sites so
+  the next contributor doesn't "fix" the missing reset.~~ —
+  `data_navigator.ex:361-369`, `data_navigator.ex:608-614`
+- ~~**F7 (LOW)** — Trash flash said "Restore it before 90 days to
+  keep it" but no Oban purge worker enforces a 90-day retention. The
+  copy was promising a deletion that doesn't happen. Replaced with
+  "Record moved to trash. Restore from the trash view." — accurate
+  and the test that asserts the flash via partial match
+  (`render(view) =~ "moved to trash"`) still passes.~~ —
+  `data_navigator.ex:313-318`
+- ~~**F8 (LOW)** — `:reverse_references` reads from
+  `Application.get_env(:phoenix_kit_entities, ...)` — a global OTP
+  app env that cross-pollinates in a multi-tenant umbrella where two
+  parent apps both register a callback for the same entity name. The
+  "multiple callbacks per entity name" semantic was already
+  documented, but the multi-tenant trap wasn't. Added an explicit
+  paragraph to `AGENTS.md` under the Reverse-reference hook section.~~
+  — `AGENTS.md:266-283`
+- ~~**F9 (NIT)** — `bulk_delete/2`'s `rescue Postgrex.Error` scope
+  spanned the entire function body, including the
+  `PhoenixKitEntities.ActivityLog.log/1` call. If the activity-log
+  write itself raised a `Postgrex.Error` (different table, different
+  transaction — theoretical), it would be misclassified as
+  `:referenced_by_external`. Extracted `run_bulk_delete_txn/1` and
+  scoped the rescue to it; the activity-log call stays outside the
+  rescue. Same fix on the single-record `delete/2`? — `do_delete/2`
+  already passes the failing `repo().delete/1` result through
+  `notify_data_event/3`, so a Postgrex error from notify-side code
+  would not slip through the rescue anyway. Left as-is.~~ —
+  `entity_data.ex:1949-1988`
+
+## Skipped (with rationale)
+
+None. All 9 findings addressed.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `lib/phoenix_kit_entities/entity_data.ex` | F1 focused changeset, F2 prior-status stash, F3 narrowed rescue + Logger import, F5 docstring, F9 rescue scope |
+| `lib/phoenix_kit_entities/web/data_navigator.ex` | F4 catch-all + comment, F6 selection-preserved comment, F7 flash copy |
+| `AGENTS.md` | F8 multi-tenant note |
+| `test/phoenix_kit_entities/entity_data_trash_test.exs` | F3 contract update — replaced the broad-rescue test with two specific ones |
+
+## Verification
+
+- `mix compile` — clean (the unrelated `sortable_handle` Hex-pin
+  warning is pre-existing — entities' Hex-pinned core doesn't yet have
+  the new draggable_list attr from `phoenix_kit#516` companion work)
+- `mix test` — **791 / 791 pass** (was 790 before; +1 from splitting
+  F3's "ignores callbacks that raise" into "swallows DB raises" plus
+  "propagates non-DB raises"). Pre-existing intermittent
+  `DBConnection.ConnectionError` log lines from sandbox shutdown
+  remain — same noise as in `main`.
+- No behaviour regression on existing trash / restore tests: all
+  setup-fixtures start from `status: "published"`, so F2's prior-
+  status stash round-trips correctly back to `"published"` on
+  restore. The bulk-restore tests (which bypass the stash because
+  `update_all` doesn't run per-row logic) still land on `"published"`
+  by default — unchanged.
+
+## Open
+
+None.

--- a/dev_docs/pull_requests/2026/14-migration-cleanup/FOLLOW_UP.md
+++ b/dev_docs/pull_requests/2026/14-migration-cleanup/FOLLOW_UP.md
@@ -1,0 +1,57 @@
+---
+name: PR #14 follow-up — test_helper migration call swap
+description: Resolution of CLAUDE_REVIEW.md findings for PR #14.
+type: project
+---
+
+# PR #14 Follow-up — Swap test_helper to ensure_current/2
+
+**Review:** [`CLAUDE_REVIEW.md`](./CLAUDE_REVIEW.md) (Claude Opus 4.7, 2026-05-05)
+**Triage:** 2026-05-12
+
+The post-merge review surfaced two non-blocking nits. Both were
+resolved in the review pass itself — see `CLAUDE_REVIEW.md` →
+`## Follow-up applied (2026-05-05)` for the original write-up. This
+file is the canonical Phase-1 follow-up record per the workspace
+playbook.
+
+## Fixed (pre-existing)
+
+- ~~**N1 (NIT)** — The inline comment in `test_helper.exs` pointed
+  at `dev_docs/migration_cleanup.md`, a file that didn't exist in
+  this repo. Replaced with a reference to the canonical write-up on
+  `PhoenixKit.Migration.ensure_current/2` upstream — the docstring
+  there covers the staleness story, clock-skew window,
+  `schema_migrations` row accumulation, and prefix forwarding.~~ —
+  `test/test_helper.exs:65-74`, resolved in the same review pass
+- ~~**N2 (LOW)** — `mix.lock` pinned `phoenix_kit 1.7.103` which
+  predated the published `PhoenixKit.Migration.ensure_current/2`
+  (1.7.105+). `mix deps.update phoenix_kit` re-resolved the lock to
+  1.7.105; the local lock is now at 1.7.106. `mix.exs` constraint
+  left at `~> 1.7` rather than tightened to `>= 1.7.105` — relying on
+  the lockfile for the floor matches the rest of the workspace.~~ —
+  `mix.lock`, resolved in the same review pass
+
+## Skipped (with rationale)
+
+None. Both nits resolved.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `test/test_helper.exs` | N1 — comment retargeted to upstream docstring |
+| `mix.lock` | N2 — `phoenix_kit` 1.7.103 → 1.7.106 (>= 1.7.105 required) |
+
+## Verification
+
+- `mix compile` — clean against the new lockfile;
+  `PhoenixKit.Migration.ensure_current/2` resolves at runtime
+- `mix test` — 791 / 791 pass (post-PR-#13-follow-up count)
+- Stale-ref grep across `lib/` + `test/` — no remaining call sites
+  of the deprecated `Ecto.Migrator.run([{0, PhoenixKit.Migration}], …)`
+  shape
+
+## Open
+
+None.

--- a/lib/phoenix_kit_entities.ex
+++ b/lib/phoenix_kit_entities.ex
@@ -156,6 +156,7 @@ defmodule PhoenixKitEntities do
   Validates that name is unique, fields_definition is valid, and all required fields are present.
   Automatically sets date_created on new records.
   """
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(entity, attrs) do
     entity
     |> cast(attrs, [
@@ -395,6 +396,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.list_active_entities()
       [%PhoenixKit.Entities{status: "published"}, ...]
   """
+  @spec list_active_entities(keyword()) :: [t()]
   def list_active_entities(opts \\ []) do
     from(e in __MODULE__,
       where: e.status == "published",
@@ -832,6 +834,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.get_system_stats()
       %{total_entities: 5, active_entities: 4, total_data_records: 150}
   """
+  @spec get_system_stats() :: map()
   def get_system_stats do
     entities_query = from(e in __MODULE__)
     data_query = from(d in PhoenixKitEntities.EntityData)
@@ -886,6 +889,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.count_all_entity_data()
       243
   """
+  @spec count_all_entity_data() :: non_neg_integer()
   def count_all_entity_data do
     from(d in PhoenixKitEntities.EntityData, select: count(d.uuid))
     |> repo().one()
@@ -1017,6 +1021,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.get_max_per_user()
       100
   """
+  @spec get_max_per_user() :: non_neg_integer()
   def get_max_per_user do
     Settings.get_integer_setting("entities_max_per_user", 100)
   end
@@ -1069,6 +1074,7 @@ defmodule PhoenixKitEntities do
   def module_name, do: "Entities"
 
   @impl PhoenixKit.Module
+  @spec permission_metadata() :: map()
   def permission_metadata do
     %{
       key: "entities",
@@ -1079,6 +1085,7 @@ defmodule PhoenixKitEntities do
   end
 
   @impl PhoenixKit.Module
+  @spec admin_tabs() :: [PhoenixKit.Dashboard.Tab.t()]
   def admin_tabs do
     [
       Tab.new!(
@@ -1129,6 +1136,8 @@ defmodule PhoenixKitEntities do
   - `entities_children(scope)` — fallback that reads the locale from
     `Gettext.get_locale/1`. Older core releases dispatch this form.
   """
+  @spec entities_children(any(), String.t() | nil) :: [PhoenixKit.Dashboard.Tab.t()]
+  @spec entities_children(any()) :: [PhoenixKit.Dashboard.Tab.t()]
   def entities_children(_scope, locale) when is_binary(locale) or is_nil(locale) do
     cached_entity_summaries(locale || Gettext.get_locale(PhoenixKitWeb.Gettext))
     |> build_entity_tabs()
@@ -1205,6 +1214,7 @@ defmodule PhoenixKitEntities do
   end
 
   @impl PhoenixKit.Module
+  @spec settings_tabs() :: [PhoenixKit.Dashboard.Tab.t()]
   def settings_tabs do
     [
       Tab.new!(
@@ -1233,6 +1243,7 @@ defmodule PhoenixKitEntities do
   def version, do: "0.1.4"
 
   @impl PhoenixKit.Module
+  @spec route_module() :: module()
   def route_module, do: PhoenixKitEntities.Routes
 
   # ============================================================================
@@ -1251,6 +1262,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.get_sort_mode(entity)
       "auto"
   """
+  @spec get_sort_mode(t()) :: String.t()
   def get_sort_mode(%__MODULE__{settings: settings}) do
     (settings || %{}) |> Map.get("sort_mode", "auto")
   end
@@ -1266,6 +1278,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.get_sort_mode_by_uuid(entity_uuid)
       "manual"
   """
+  @spec get_sort_mode_by_uuid(binary()) :: String.t()
   def get_sort_mode_by_uuid(entity_uuid) when is_binary(entity_uuid) do
     case get_entity(entity_uuid) do
       nil -> "auto"
@@ -1281,6 +1294,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.manual_sort?(entity)
       true
   """
+  @spec manual_sort?(t()) :: boolean()
   def manual_sort?(%__MODULE__{} = entity), do: get_sort_mode(entity) == "manual"
 
   @doc """
@@ -1296,6 +1310,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.update_sort_mode(entity, "manual")
       {:ok, %PhoenixKitEntities{}}
   """
+  @spec update_sort_mode(t(), String.t()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
   def update_sort_mode(%__MODULE__{} = entity, mode) when mode in @valid_sort_modes do
     current_settings = entity.settings || %{}
     new_settings = Map.put(current_settings, "sort_mode", mode)
@@ -1317,6 +1332,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.get_mirror_settings(entity)
       %{mirror_definitions: true, mirror_data: false}
   """
+  @spec get_mirror_settings(t()) :: %{definitions: boolean(), data: boolean()}
   def get_mirror_settings(%__MODULE__{settings: settings}) do
     settings = settings || %{}
 
@@ -1334,6 +1350,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.mirror_definitions_enabled?(entity)
       true
   """
+  @spec mirror_definitions_enabled?(t()) :: boolean()
   def mirror_definitions_enabled?(%__MODULE__{settings: settings}) do
     settings = settings || %{}
     Map.get(settings, "mirror_definitions", false) == true
@@ -1347,6 +1364,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.mirror_data_enabled?(entity)
       false
   """
+  @spec mirror_data_enabled?(t()) :: boolean()
   def mirror_data_enabled?(%__MODULE__{settings: settings}) do
     settings = settings || %{}
     Map.get(settings, "mirror_data", false) == true
@@ -1364,6 +1382,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.update_mirror_settings(entity, %{"mirror_definitions" => true})
       {:ok, %PhoenixKit.Entities{}}
   """
+  @spec update_mirror_settings(t(), map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
   def update_mirror_settings(%__MODULE__{} = entity, mirror_settings)
       when is_map(mirror_settings) do
     current_settings = entity.settings || %{}
@@ -1382,6 +1401,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.list_entities_with_mirror_status()
       [%{id: 1, name: "test", display_name: "Test", data_count: 8, mirror_definitions: true, mirror_data: false}, ...]
   """
+  @spec list_entities_with_mirror_status() :: [map()]
   def list_entities_with_mirror_status do
     entities = list_entities()
 
@@ -1410,6 +1430,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.enable_all_definitions_mirror()
       {:ok, count}
   """
+  @spec enable_all_definitions_mirror() :: {non_neg_integer(), nil}
   def enable_all_definitions_mirror do
     entities = list_entities()
 
@@ -1430,6 +1451,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.disable_all_definitions_mirror()
       {:ok, count}
   """
+  @spec disable_all_definitions_mirror() :: {non_neg_integer(), nil}
   def disable_all_definitions_mirror do
     entities = list_entities()
 
@@ -1450,6 +1472,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.enable_all_data_mirror()
       {:ok, count}
   """
+  @spec enable_all_data_mirror() :: {non_neg_integer(), nil}
   def enable_all_data_mirror do
     entities = list_entities()
 
@@ -1470,6 +1493,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.disable_all_data_mirror()
       {:ok, count}
   """
+  @spec disable_all_data_mirror() :: {non_neg_integer(), nil}
   def disable_all_data_mirror do
     entities = list_entities()
 
@@ -1503,6 +1527,7 @@ defmodule PhoenixKitEntities do
       iex> get_entity_translations(entity_without_translations)
       %{}
   """
+  @spec get_entity_translations(t()) :: %{optional(String.t()) => map()}
   def get_entity_translations(%__MODULE__{settings: settings}) do
     (settings || %{})
     |> Map.get("translations", %{})
@@ -1519,6 +1544,7 @@ defmodule PhoenixKitEntities do
       iex> get_entity_translation(entity, "es-ES")
       %{"display_name" => "Productos", "display_name_plural" => "Productos", "description" => "..."}
   """
+  @spec get_entity_translation(t(), String.t()) :: map() | nil
   def get_entity_translation(%__MODULE__{} = entity, lang_code) when is_binary(lang_code) do
     primary = %{
       "display_name" => entity.display_name,
@@ -1546,6 +1572,8 @@ defmodule PhoenixKitEntities do
       ...> })
       {:ok, %PhoenixKitEntities{}}
   """
+  @spec set_entity_translation(t(), String.t(), map()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t()}
   def set_entity_translation(%__MODULE__{} = entity, lang_code, attrs)
       when is_binary(lang_code) and is_map(attrs) do
     current_settings = entity.settings || %{}
@@ -1585,6 +1613,8 @@ defmodule PhoenixKitEntities do
       iex> remove_entity_translation(entity, "es-ES")
       {:ok, %PhoenixKitEntities{}}
   """
+  @spec remove_entity_translation(t(), String.t()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t()}
   def remove_entity_translation(%__MODULE__{} = entity, lang_code)
       when is_binary(lang_code) do
     current_settings = entity.settings || %{}
@@ -1611,6 +1641,7 @@ defmodule PhoenixKitEntities do
       iex> PhoenixKitEntities.multilang_enabled?()
       true
   """
+  @spec multilang_enabled?() :: boolean()
   def multilang_enabled?, do: Multilang.enabled?()
 
   # ============================================================================
@@ -1638,6 +1669,7 @@ defmodule PhoenixKitEntities do
   @spec resolve_language(t(), String.t() | nil) :: t()
   def resolve_language(entity, nil), do: entity
 
+  @spec resolve_language(t(), String.t()) :: t()
   def resolve_language(%__MODULE__{} = entity, lang_code) when is_binary(lang_code) do
     translation = get_entity_translation(entity, lang_code)
 
@@ -1665,11 +1697,13 @@ defmodule PhoenixKitEntities do
   @spec resolve_languages([t()], String.t() | nil) :: [t()]
   def resolve_languages(entities, nil), do: entities
 
+  @spec resolve_languages([t()], String.t()) :: [t()]
   def resolve_languages(entities, lang_code) when is_list(entities) and is_binary(lang_code) do
     Enum.map(entities, &resolve_language(&1, lang_code))
   end
 
   @doc false
+  @spec maybe_resolve_lang(t(), keyword()) :: t()
   def maybe_resolve_lang(entity, opts) when is_list(opts) do
     case Keyword.get(opts, :lang) do
       nil -> entity

--- a/lib/phoenix_kit_entities/controllers/entity_form_controller.ex
+++ b/lib/phoenix_kit_entities/controllers/entity_form_controller.ex
@@ -534,15 +534,38 @@ defmodule PhoenixKitEntities.Controllers.EntityFormController do
     end)
   end
 
+  # Honor the Referer header only when it points back at the same host
+  # we're serving from. The header is attacker-controllable (any page
+  # can link/post here with a crafted Referer), so passing it raw into
+  # `redirect(external: …)` was an open-redirect surface — phishing
+  # bait that bounces through this app's domain. We parse it, require
+  # an http/https scheme + host match against `conn.host`, and emit a
+  # path-only relative redirect with the host stripped. Anything that
+  # doesn't pass falls back to "/".
   defp redirect_back(conn, _fallback_conn) do
-    referer = get_req_header(conn, "referer") |> List.first()
-
-    if referer do
-      redirect(conn, external: referer)
-    else
-      redirect(conn, to: "/")
+    case get_req_header(conn, "referer") |> List.first() do
+      nil -> redirect(conn, to: "/")
+      referer -> redirect(conn, to: safe_referer_path(referer, conn.host) || "/")
     end
   end
+
+  defp safe_referer_path(referer, expected_host) when is_binary(referer) do
+    case URI.parse(referer) do
+      %URI{scheme: scheme, host: ^expected_host, path: path}
+      when scheme in ["http", "https"] and is_binary(path) ->
+        # Reattach query so the user lands back exactly where they
+        # came from (filters, scroll position, etc).
+        case URI.parse(referer).query do
+          nil -> path
+          q -> path <> "?" <> q
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp safe_referer_path(_, _), do: nil
 
   # Form statistics tracking
   # Stats are stored in entity.settings under "public_form_stats".

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -147,6 +147,7 @@ defmodule PhoenixKitEntities.EntityData do
   Validates that entity exists, title is present, and data validates against entity definition.
   Automatically sets date_created on new records.
   """
+  @spec changeset(t() | Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   def changeset(entity_data, attrs) do
     entity_data
     |> cast(attrs, [
@@ -697,6 +698,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.list_all()
       [%PhoenixKitEntities.EntityData{}, ...]
   """
+  @spec list_all(keyword()) :: [t()]
   def list_all(opts \\ []) do
     from(d in __MODULE__,
       order_by: [desc: d.date_created],
@@ -718,6 +720,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.list_by_entity(entity_uuid)
       [%PhoenixKitEntities.EntityData{}, ...]
   """
+  @spec list_by_entity(binary(), keyword()) :: [t()]
   def list_by_entity(entity_uuid, opts \\ []) when is_binary(entity_uuid) do
     order = resolve_sort_order(entity_uuid, opts)
 
@@ -855,6 +858,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.list_by_entity_and_status(entity_uuid, "published")
       [%PhoenixKitEntities.EntityData{status: "published"}, ...]
   """
+  @spec list_by_entity_and_status(binary(), String.t(), keyword()) :: [t()]
   def list_by_entity_and_status(entity_uuid, status, opts \\ [])
       when is_binary(entity_uuid) and status in @valid_statuses do
     order = resolve_sort_order(entity_uuid, opts)
@@ -881,6 +885,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.get("invalid")
       nil
   """
+  @spec get(any(), keyword()) :: t() | nil
   def get(uuid, opts \\ [])
 
   def get(uuid, opts) when is_binary(uuid) do
@@ -909,6 +914,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.get!("nonexistent-uuid")
       ** (Ecto.NoResultsError)
   """
+  @spec get!(binary(), keyword()) :: t()
   def get!(id, opts \\ []) do
     case get(id, opts) do
       nil -> raise Ecto.NoResultsError, queryable: __MODULE__
@@ -929,6 +935,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.get_by_slug(entity_uuid, "invalid")
       nil
   """
+  @spec get_by_slug(binary(), String.t(), keyword()) :: t() | nil
   def get_by_slug(entity_uuid, slug, opts \\ [])
       when is_binary(entity_uuid) and is_binary(slug) do
     case repo().get_by(__MODULE__, entity_uuid: entity_uuid, slug: slug) do
@@ -943,6 +950,7 @@ defmodule PhoenixKitEntities.EntityData do
   Queries the JSONB `data` column for `data->lang_code->>'_slug'` matches.
   Used for uniqueness checks on translated slugs.
   """
+  @spec secondary_slug_exists?(binary(), String.t(), String.t(), binary() | nil) :: boolean()
   def secondary_slug_exists?(entity_uuid, lang_code, slug, exclude_record_uuid)
       when is_binary(entity_uuid) do
     query =
@@ -1035,6 +1043,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> next_position(entity_uuid)
       6
   """
+  @spec next_position(binary()) :: non_neg_integer()
   def next_position(entity_uuid) when is_binary(entity_uuid) do
     # FOR UPDATE locks matching rows within a transaction to prevent
     # concurrent creates from reading the same max position.
@@ -1061,6 +1070,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> update_position(record, 3)
       {:ok, %EntityData{position: 3}}
   """
+  @spec update_position(t(), integer()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
   def update_position(%__MODULE__{} = entity_data, position) when is_integer(position) do
     __MODULE__.update(entity_data, %{position: position})
   end
@@ -1095,6 +1105,8 @@ defmodule PhoenixKitEntities.EntityData do
       iex> bulk_update_positions([{"uuid1", 1}, {"uuid2", 2}, {"uuid3", 3}], entity_uuid: e_uuid)
       :ok
   """
+  @spec bulk_update_positions([{binary(), integer()}], keyword()) ::
+          :ok | {:error, :too_many_uuids | term()}
   def bulk_update_positions(uuid_position_pairs, opts \\ [])
 
   def bulk_update_positions(uuid_position_pairs, opts)
@@ -1154,6 +1166,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> move_to_position(record, 3)
       :ok
   """
+  @spec move_to_position(t(), integer()) :: :ok | {:error, term()}
   def move_to_position(%__MODULE__{} = record, new_position) when is_integer(new_position) do
     entity_uuid = record.entity_uuid
 
@@ -1234,6 +1247,8 @@ defmodule PhoenixKitEntities.EntityData do
       iex> reorder(entity_uuid, ["uuid3", "uuid1", "uuid2"])
       :ok
   """
+  @spec reorder(binary(), [binary()], keyword()) ::
+          :ok | {:error, :too_many_uuids | term()}
   def reorder(entity_uuid, ordered_uuids, opts \\ [])
       when is_binary(entity_uuid) and is_list(ordered_uuids) do
     pairs =
@@ -1287,20 +1302,19 @@ defmodule PhoenixKitEntities.EntityData do
           {:ok, t()}
           | {:error, Ecto.Changeset.t() | :referenced_by_external | :has_children}
   def delete(%__MODULE__{} = entity_data, opts \\ []) do
-    if has_live_children?(entity_data.uuid) do
-      log_data_error_activity(:deleted, opts)
-      {:error, :has_children}
-    else
-      do_delete(entity_data, opts)
-    end
-  end
-
-  defp do_delete(entity_data, opts) do
-    # Null any trashed children's parent_uuid first so the DB-level
-    # self-FK doesn't block the parent's delete. Live children would
-    # have tripped `has_live_children?/1` already.
+    # Fold the child check INSIDE the transaction so a concurrent
+    # insert can't slip a live child between the check and the delete
+    # (which would otherwise trip the DB-level FK and surface as
+    # `:referenced_by_external` instead of the more accurate
+    # `:has_children`).
     txn =
       repo().transaction(fn ->
+        if has_live_children?(entity_data.uuid) do
+          repo().rollback(:has_children)
+        end
+
+        # Null any trashed children's parent_uuid first so the DB-level
+        # self-FK doesn't block the parent's delete.
         nullify_trashed_children([entity_data.uuid])
 
         case repo().delete(entity_data) do
@@ -1312,6 +1326,10 @@ defmodule PhoenixKitEntities.EntityData do
     case txn do
       {:ok, deleted} ->
         notify_data_event({:ok, deleted}, :deleted, opts)
+
+      {:error, :has_children} ->
+        log_data_error_activity(:deleted, opts)
+        {:error, :has_children}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:error, changeset}
@@ -1468,6 +1486,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.change(record)
       %Ecto.Changeset{data: %PhoenixKitEntities.EntityData{}}
   """
+  @spec change(t(), map()) :: Ecto.Changeset.t()
   def change(%__MODULE__{} = entity_data, attrs \\ %{}) do
     changeset(entity_data, attrs)
   end
@@ -1486,6 +1505,8 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.search_by_title("Acme", entity_uuid, lang: "es")
       [%PhoenixKitEntities.EntityData{}, ...]
   """
+  @spec search_by_title(String.t()) :: [t()]
+  @spec search_by_title(String.t(), binary() | nil, keyword()) :: [t()]
   def search_by_title(search_term) when is_binary(search_term),
     do: search_by_title(search_term, nil, [])
 
@@ -1526,6 +1547,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.published_records(entity_uuid)
       [%PhoenixKitEntities.EntityData{status: "published"}, ...]
   """
+  @spec published_records(binary(), keyword()) :: [t()]
   def published_records(entity_uuid, opts \\ []) when is_binary(entity_uuid) do
     list_by_entity_and_status(entity_uuid, "published", opts)
   end
@@ -1544,6 +1566,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.count_by_entity(entity_uuid, include_trashed: true)
       45
   """
+  @spec count_by_entity(binary(), keyword()) :: non_neg_integer()
   def count_by_entity(entity_uuid, opts \\ []) when is_binary(entity_uuid) do
     from(d in __MODULE__, where: d.entity_uuid == ^entity_uuid, select: count(d.uuid))
     |> exclude_trashed(opts)
@@ -1574,6 +1597,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> PhoenixKitEntities.EntityData.filter_by_status("draft")
       [%PhoenixKitEntities.EntityData{status: "draft"}, ...]
   """
+  @spec filter_by_status(String.t(), keyword()) :: [t()]
   def filter_by_status(status, opts \\ []) when status in @valid_statuses do
     from(d in __MODULE__,
       where: d.status == ^status,
@@ -1774,21 +1798,26 @@ defmodule PhoenixKitEntities.EntityData do
   @doc """
   Alias for list_all/1 for consistency with LiveView naming.
   """
+  @spec list_all_data(keyword()) :: [t()]
   def list_all_data(opts \\ []), do: list_all(opts)
 
   @doc """
   Alias for list_by_entity/2 for consistency with LiveView naming.
   """
+  @spec list_data_by_entity(binary(), keyword()) :: [t()]
   def list_data_by_entity(entity_uuid, opts \\ []), do: list_by_entity(entity_uuid, opts)
 
   @doc """
   Alias for filter_by_status/2 for consistency with LiveView naming.
   """
+  @spec list_data_by_status(String.t(), keyword()) :: [t()]
   def list_data_by_status(status, opts \\ []), do: filter_by_status(status, opts)
 
   @doc """
   Alias for search_by_title for consistency with LiveView naming.
   """
+  @spec search_data(String.t()) :: [t()]
+  @spec search_data(String.t(), binary() | nil, keyword()) :: [t()]
   def search_data(search_term) when is_binary(search_term),
     do: search_by_title(search_term, nil, [])
 
@@ -1798,6 +1827,7 @@ defmodule PhoenixKitEntities.EntityData do
   @doc """
   Alias for get!/2 for consistency with LiveView naming.
   """
+  @spec get_data!(binary(), keyword()) :: t()
   def get_data!(id, opts \\ []), do: get!(id, opts)
 
   @doc """
@@ -1977,19 +2007,8 @@ defmodule PhoenixKitEntities.EntityData do
           {non_neg_integer(), nil}
           | {:error, :referenced_by_external | :has_children}
   def bulk_delete(uuids, opts \\ []) when is_list(uuids) do
-    if has_external_live_children?(uuids) do
-      log_data_error_activity(:bulk_deleted, opts)
-      {:error, :has_children}
-    else
-      do_bulk_delete(uuids, opts)
-    end
-  end
-
-  defp do_bulk_delete(uuids, opts) do
-    # Wrap ONLY the transaction in the rescue so an `ActivityLog.log`
-    # failure can't be misclassified as `:referenced_by_external`. The
-    # transaction itself returns `{:error, _}` on rollback; raised
-    # Postgrex errors are the FK / NOT NULL paths.
+    # Wrap the activity-log call OUTSIDE the transaction so a logging
+    # failure can't be misclassified as `:referenced_by_external`.
     case run_bulk_delete_txn(uuids) do
       {:ok, {count, _} = result} ->
         PhoenixKitEntities.ActivityLog.log(%{
@@ -2005,6 +2024,10 @@ defmodule PhoenixKitEntities.EntityData do
 
         result
 
+      {:error, :has_children} ->
+        log_data_error_activity(:bulk_deleted, opts)
+        {:error, :has_children}
+
       {:error, _} ->
         log_data_error_activity(:bulk_deleted, opts)
         {:error, :referenced_by_external}
@@ -2013,9 +2036,15 @@ defmodule PhoenixKitEntities.EntityData do
 
   defp run_bulk_delete_txn(uuids) do
     repo().transaction(fn ->
+      # Fold the check inside the transaction so a concurrent insert
+      # can't land a live external child between the check and the
+      # delete.
+      if has_external_live_children?(uuids) do
+        repo().rollback(:has_children)
+      end
+
       # Null trashed children of any row in the input set before
-      # deleting, so the self-FK doesn't block. Live external
-      # children would have tripped `has_external_live_children?/1`.
+      # deleting, so the self-FK doesn't block.
       nullify_trashed_children(uuids)
 
       from(d in __MODULE__, where: d.uuid in ^uuids)
@@ -2149,6 +2178,13 @@ defmodule PhoenixKitEntities.EntityData do
         trashed_records: 3
       }
   """
+  @spec get_data_stats(binary() | nil) :: %{
+          total_records: non_neg_integer(),
+          published_records: non_neg_integer(),
+          draft_records: non_neg_integer(),
+          archived_records: non_neg_integer(),
+          trashed_records: non_neg_integer()
+        }
   def get_data_stats(entity_uuid \\ nil) do
     query =
       from(d in __MODULE__,
@@ -2199,6 +2235,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> get_translation(flat_record, "en-US")
       %{"name" => "Acme", "category" => "Tech"}
   """
+  @spec get_translation(t(), String.t()) :: map()
   def get_translation(%__MODULE__{data: data}, lang_code) when is_binary(lang_code) do
     Multilang.get_language_data(data, lang_code)
   end
@@ -2214,6 +2251,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> get_raw_translation(record, "es-ES")
       %{"name" => "Acme España"}
   """
+  @spec get_raw_translation(t(), String.t()) :: map()
   def get_raw_translation(%__MODULE__{data: data}, lang_code) when is_binary(lang_code) do
     Multilang.get_raw_language_data(data, lang_code)
   end
@@ -2232,6 +2270,7 @@ defmodule PhoenixKitEntities.EntityData do
         "es-ES" => %{"name" => "Acme España", "category" => "Tech"}
       }
   """
+  @spec get_all_translations(t()) :: %{optional(String.t()) => map()}
   def get_all_translations(%__MODULE__{data: data}) do
     if Multilang.multilang_data?(data) do
       Multilang.enabled_languages()
@@ -2257,6 +2296,8 @@ defmodule PhoenixKitEntities.EntityData do
       iex> set_translation(record, "en-US", %{"name" => "Acme Corp", "category" => "Tech"})
       {:ok, %EntityData{}}
   """
+  @spec set_translation(t(), String.t(), map()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t()}
   def set_translation(%__MODULE__{} = entity_data, lang_code, field_data)
       when is_binary(lang_code) and is_map(field_data) do
     updated_data = Multilang.put_language_data(entity_data.data, lang_code, field_data)
@@ -2277,6 +2318,9 @@ defmodule PhoenixKitEntities.EntityData do
       iex> remove_translation(record, "en-US")
       {:error, :cannot_remove_primary}
   """
+  @spec remove_translation(t(), String.t()) ::
+          {:ok, t()}
+          | {:error, :cannot_remove_primary | :not_multilang | Ecto.Changeset.t()}
   def remove_translation(%__MODULE__{data: data} = entity_data, lang_code)
       when is_binary(lang_code) do
     if Multilang.multilang_data?(data) do
@@ -2308,6 +2352,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> get_title_translation(record, "es-ES")
       "Mi Producto"
   """
+  @spec get_title_translation(t(), String.t()) :: String.t() | nil
   def get_title_translation(%__MODULE__{} = entity_data, lang_code)
       when is_binary(lang_code) do
     case Multilang.get_language_data(entity_data.data, lang_code) do
@@ -2337,6 +2382,8 @@ defmodule PhoenixKitEntities.EntityData do
       iex> set_title_translation(record, "en-US", "My Product")
       {:ok, %EntityData{}}
   """
+  @spec set_title_translation(t(), String.t(), String.t()) ::
+          {:ok, t()} | {:error, Ecto.Changeset.t()}
   def set_title_translation(%__MODULE__{} = entity_data, lang_code, title)
       when is_binary(lang_code) and is_binary(title) do
     # Merge _title into existing raw overrides to preserve other fields
@@ -2362,6 +2409,7 @@ defmodule PhoenixKitEntities.EntityData do
       iex> get_all_title_translations(record)
       %{"en-US" => "My Product", "es-ES" => "Mi Producto", "fr-FR" => "Mon Produit"}
   """
+  @spec get_all_title_translations(t()) :: %{optional(String.t()) => String.t() | nil}
   def get_all_title_translations(%__MODULE__{} = entity_data) do
     Multilang.enabled_languages()
     |> Map.new(fn lang ->

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -94,6 +94,7 @@ defmodule PhoenixKitEntities.EntityData do
            only: [
              :uuid,
              :entity_uuid,
+             :parent_uuid,
              :title,
              :slug,
              :status,
@@ -117,6 +118,17 @@ defmodule PhoenixKitEntities.EntityData do
 
     belongs_to(:entity, Entities, foreign_key: :entity_uuid, references: :uuid, type: UUIDv7)
 
+    belongs_to(:parent, __MODULE__,
+      foreign_key: :parent_uuid,
+      references: :uuid,
+      type: UUIDv7
+    )
+
+    has_many(:children, __MODULE__,
+      foreign_key: :parent_uuid,
+      references: :uuid
+    )
+
     belongs_to(:creator, User,
       foreign_key: :created_by_uuid,
       references: :uuid,
@@ -138,6 +150,7 @@ defmodule PhoenixKitEntities.EntityData do
     entity_data
     |> cast(attrs, [
       :entity_uuid,
+      :parent_uuid,
       :title,
       :slug,
       :status,
@@ -154,10 +167,109 @@ defmodule PhoenixKitEntities.EntityData do
     |> validate_length(:slug, max: 255)
     |> validate_inclusion(:status, @valid_statuses)
     |> validate_slug_format()
+    |> validate_not_self_parent()
+    |> validate_parent_same_entity()
+    |> validate_parent_not_descendant()
     |> sanitize_rich_text_data()
     |> validate_data_against_entity()
     |> foreign_key_constraint(:entity_uuid)
+    |> foreign_key_constraint(:parent_uuid)
     |> maybe_set_timestamps()
+  end
+
+  defp validate_not_self_parent(changeset) do
+    uuid = get_field(changeset, :uuid)
+    parent = get_field(changeset, :parent_uuid)
+
+    if not is_nil(uuid) and not is_nil(parent) and uuid == parent do
+      add_error(changeset, :parent_uuid, gettext("a record cannot be its own parent"))
+    else
+      changeset
+    end
+  end
+
+  # Same-entity enforcement happens here (the DB self-FK has no view of
+  # entity_uuid, so we look up the parent and compare). NULL parent_uuid
+  # is fine — that means "root".
+  defp validate_parent_same_entity(changeset) do
+    entity_uuid = get_field(changeset, :entity_uuid)
+    parent_uuid = get_field(changeset, :parent_uuid)
+
+    case {entity_uuid, parent_uuid} do
+      {nil, _} -> changeset
+      {_, nil} -> changeset
+      {ent, parent_id} -> check_parent_entity_match(changeset, ent, parent_id)
+    end
+  end
+
+  defp check_parent_entity_match(changeset, entity_uuid, parent_uuid) do
+    case repo().get(__MODULE__, parent_uuid) do
+      nil ->
+        add_error(changeset, :parent_uuid, gettext("parent record does not exist"))
+
+      %__MODULE__{entity_uuid: ^entity_uuid} ->
+        changeset
+
+      _other_entity ->
+        add_error(
+          changeset,
+          :parent_uuid,
+          gettext("parent must belong to the same entity")
+        )
+    end
+  rescue
+    # If the repo isn't started yet (compile-time, etc.) leave parent
+    # alone — the DB-level FK will catch a bogus id at insert time.
+    DBConnection.ConnectionError -> changeset
+    Postgrex.Error -> changeset
+  end
+
+  # Walk up from the proposed parent toward the root; if we ever hit
+  # the row we are editing, the parent assignment would create a cycle.
+  # Only meaningful when both uuids are present and distinct (the
+  # self-parent check covers the equal case).
+  defp validate_parent_not_descendant(changeset) do
+    uuid = get_field(changeset, :uuid)
+    parent_uuid = get_field(changeset, :parent_uuid)
+
+    case {uuid, parent_uuid} do
+      {nil, _} -> changeset
+      {_, nil} -> changeset
+      {same, same} -> changeset
+      {self_id, parent_id} -> check_no_cycle(changeset, self_id, parent_id)
+    end
+  end
+
+  defp check_no_cycle(changeset, self_id, parent_id) do
+    if ancestor_chain_contains?(parent_id, self_id, 0) do
+      add_error(
+        changeset,
+        :parent_uuid,
+        gettext("parent cannot be one of this record's descendants")
+      )
+    else
+      changeset
+    end
+  rescue
+    DBConnection.ConnectionError -> changeset
+    Postgrex.Error -> changeset
+  end
+
+  # Bounded walk — a tree this deep is a bug, but the guard keeps the
+  # validator from looping forever if the DB somehow already has a
+  # cycle (shouldn't happen, but be defensive).
+  @max_ancestor_depth 64
+
+  defp ancestor_chain_contains?(_uuid, _target, depth) when depth >= @max_ancestor_depth,
+    do: false
+
+  defp ancestor_chain_contains?(uuid, target, depth) do
+    case repo().get(__MODULE__, uuid) do
+      nil -> false
+      %__MODULE__{parent_uuid: nil} -> false
+      %__MODULE__{parent_uuid: ^target} -> true
+      %__MODULE__{parent_uuid: next} -> ancestor_chain_contains?(next, target, depth + 1)
+    end
   end
 
   defp validate_entity_reference(changeset) do
@@ -616,6 +728,90 @@ defmodule PhoenixKitEntities.EntityData do
     |> exclude_trashed(opts)
     |> repo().all()
     |> maybe_resolve_langs(opts)
+  end
+
+  @doc """
+  Returns the entity's records as a depth-ordered flat list for
+  WordPress-style indented rendering — parents precede their children,
+  siblings preserve the entity's current sort order.
+
+  Each element is `%{record: %EntityData{}, depth: integer}` where
+  depth `0` is a root row.
+
+  ## Options
+
+  * `:include_trashed` — when `true`, include trashed rows (default `false`)
+  * `:lang` — resolve multilingual fields to the given locale
+  * any other opt accepted by `list_by_entity/2`
+  """
+  @spec list_tree(binary(), keyword()) :: [%{record: t(), depth: non_neg_integer()}]
+  def list_tree(entity_uuid, opts \\ []) when is_binary(entity_uuid) do
+    rows = list_by_entity(entity_uuid, opts)
+    build_tree(rows)
+  end
+
+  @doc """
+  Returns all descendant UUIDs of a record (children, grandchildren, …).
+
+  Used by the parent picker to exclude rows that would create a cycle.
+  Walks the in-memory tree of the same entity rather than recursing
+  through the DB. Trashed rows are excluded by default — they cannot
+  meaningfully participate in a new cycle and including them would
+  leak trashed rows into the picker's exclusion set.
+
+  Returns `[]` for unknown / NULL `uuid`.
+
+  ## Options
+
+  * `:include_trashed` — when `true`, include trashed descendants
+  """
+  @spec descendant_uuids(binary() | nil, binary(), keyword()) :: [binary()]
+  def descendant_uuids(uuid, entity_uuid, opts \\ [])
+
+  def descendant_uuids(nil, _entity_uuid, _opts), do: []
+
+  def descendant_uuids(uuid, entity_uuid, opts)
+      when is_binary(uuid) and is_binary(entity_uuid) do
+    rows = list_by_entity(entity_uuid, opts)
+    children_by_parent = group_by_parent(rows)
+    collect_descendants(uuid, children_by_parent, [])
+  end
+
+  # Build a depth-ordered flat list from a sibling-ordered row list.
+  # Rows whose parent_uuid points outside the input set surface as
+  # roots (defensive — a misaligned parent reference can't hide rows
+  # from the admin view).
+  defp build_tree(rows) do
+    by_parent = group_by_parent(rows)
+    known_uuids = MapSet.new(rows, & &1.uuid)
+
+    roots =
+      Enum.filter(rows, fn row ->
+        is_nil(row.parent_uuid) or not MapSet.member?(known_uuids, row.parent_uuid)
+      end)
+
+    Enum.flat_map(roots, &walk_tree(&1, by_parent, 0))
+  end
+
+  defp walk_tree(row, by_parent, depth) do
+    children = Map.get(by_parent, row.uuid, [])
+    [%{record: row, depth: depth} | Enum.flat_map(children, &walk_tree(&1, by_parent, depth + 1))]
+  end
+
+  defp group_by_parent(rows) do
+    Enum.group_by(rows, & &1.parent_uuid)
+  end
+
+  defp collect_descendants(uuid, children_by_parent, acc) do
+    case Map.get(children_by_parent, uuid, []) do
+      [] ->
+        acc
+
+      children ->
+        Enum.reduce(children, acc, fn child, inner_acc ->
+          collect_descendants(child.uuid, children_by_parent, [child.uuid | inner_acc])
+        end)
+    end
   end
 
   @doc """
@@ -1087,10 +1283,38 @@ defmodule PhoenixKitEntities.EntityData do
       {:error, :referenced_by_external}
   """
   @spec delete(t(), keyword()) ::
-          {:ok, t()} | {:error, Ecto.Changeset.t() | :referenced_by_external}
+          {:ok, t()}
+          | {:error, Ecto.Changeset.t() | :referenced_by_external | :has_children}
   def delete(%__MODULE__{} = entity_data, opts \\ []) do
-    repo().delete(entity_data)
-    |> notify_data_event(:deleted, opts)
+    if has_live_children?(entity_data.uuid) do
+      log_data_error_activity(:deleted, opts)
+      {:error, :has_children}
+    else
+      do_delete(entity_data, opts)
+    end
+  end
+
+  defp do_delete(entity_data, opts) do
+    # Null any trashed children's parent_uuid first so the DB-level
+    # self-FK doesn't block the parent's delete. Live children would
+    # have tripped `has_live_children?/1` already.
+    txn =
+      repo().transaction(fn ->
+        nullify_trashed_children([entity_data.uuid])
+
+        case repo().delete(entity_data) do
+          {:ok, deleted} -> deleted
+          {:error, changeset} -> repo().rollback(changeset)
+        end
+      end)
+
+    case txn do
+      {:ok, deleted} ->
+        notify_data_event({:ok, deleted}, :deleted, opts)
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:error, changeset}
+    end
   rescue
     # Ecto wraps Postgrex FK violations on Repo.delete in
     # `Ecto.ConstraintError` because `delete/1` doesn't go through a
@@ -1110,6 +1334,27 @@ defmodule PhoenixKitEntities.EntityData do
       else
         reraise e, __STACKTRACE__
       end
+  end
+
+  defp nullify_trashed_children(parent_uuids) when is_list(parent_uuids) do
+    from(d in __MODULE__,
+      where: d.parent_uuid in ^parent_uuids and d.status == ^@soft_delete_status
+    )
+    |> repo().update_all(set: [parent_uuid: nil])
+  end
+
+  # "Live" children = non-trashed rows whose parent_uuid points at this
+  # record. Trashed children don't block hard-delete: their row stays
+  # alive in the DB only to keep parent-app FKs resolving — for
+  # entity-internal tree integrity they're invisible.
+  defp has_live_children?(uuid) when is_binary(uuid) do
+    from(d in __MODULE__,
+      where: d.parent_uuid == ^uuid and d.status != ^@soft_delete_status,
+      select: 1,
+      limit: 1
+    )
+    |> repo().one()
+    |> Kernel.!=(nil)
   end
 
   @doc """
@@ -1684,25 +1929,48 @@ defmodule PhoenixKitEntities.EntityData do
       {:error, :referenced_by_external}
   """
   @spec bulk_delete([String.t()], keyword()) ::
-          {non_neg_integer(), nil} | {:error, :referenced_by_external}
+          {non_neg_integer(), nil}
+          | {:error, :referenced_by_external | :has_children}
   def bulk_delete(uuids, opts \\ []) when is_list(uuids) do
-    {count, _} =
-      result =
-      from(d in __MODULE__, where: d.uuid in ^uuids)
-      |> repo().delete_all()
+    if has_external_live_children?(uuids) do
+      log_data_error_activity(:bulk_deleted, opts)
+      {:error, :has_children}
+    else
+      do_bulk_delete(uuids, opts)
+    end
+  end
 
-    PhoenixKitEntities.ActivityLog.log(%{
-      action: "entity_data.bulk_deleted",
-      mode: "manual",
-      actor_uuid: Keyword.get(opts, :actor_uuid),
-      resource_type: "entity_data",
-      metadata: %{
-        "count" => count,
-        "uuid_count" => length(uuids)
-      }
-    })
+  defp do_bulk_delete(uuids, opts) do
+    txn =
+      repo().transaction(fn ->
+        # Null trashed children of any row in the input set before
+        # deleting, so the self-FK doesn't block. Live external
+        # children would have tripped `has_external_live_children?/1`.
+        nullify_trashed_children(uuids)
 
-    result
+        from(d in __MODULE__, where: d.uuid in ^uuids)
+        |> repo().delete_all()
+      end)
+
+    case txn do
+      {:ok, {count, _} = result} ->
+        PhoenixKitEntities.ActivityLog.log(%{
+          action: "entity_data.bulk_deleted",
+          mode: "manual",
+          actor_uuid: Keyword.get(opts, :actor_uuid),
+          resource_type: "entity_data",
+          metadata: %{
+            "count" => count,
+            "uuid_count" => length(uuids)
+          }
+        })
+
+        result
+
+      {:error, _} ->
+        log_data_error_activity(:bulk_deleted, opts)
+        {:error, :referenced_by_external}
+    end
   rescue
     e in Postgrex.Error ->
       if foreign_key_or_not_null_violation?(e) do
@@ -1711,6 +1979,25 @@ defmodule PhoenixKitEntities.EntityData do
       else
         reraise e, __STACKTRACE__
       end
+  end
+
+  # A child is "external" to the bulk_delete set if its parent is being
+  # deleted but the child itself is not. Children that are also in the
+  # input list are fine — they get deleted alongside their parent.
+  # Trashed children don't block (same rule as the single-record path).
+  defp has_external_live_children?([]), do: false
+
+  defp has_external_live_children?(uuids) when is_list(uuids) do
+    from(d in __MODULE__,
+      where:
+        d.parent_uuid in ^uuids and
+          d.status != ^@soft_delete_status and
+          d.uuid not in ^uuids,
+      select: 1,
+      limit: 1
+    )
+    |> repo().one()
+    |> Kernel.!=(nil)
   end
 
   @doc """

--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -74,6 +74,7 @@ defmodule PhoenixKitEntities.EntityData do
   use Gettext, backend: PhoenixKitWeb.Gettext
   import Ecto.Changeset
   import Ecto.Query, warn: false
+  require Logger
 
   alias PhoenixKit.Modules.Languages.DialectMapper
   alias PhoenixKit.Users.Auth
@@ -1377,8 +1378,15 @@ defmodule PhoenixKitEntities.EntityData do
   def trash(%__MODULE__{status: @soft_delete_status}, _opts), do: {:error, :already_trashed}
 
   def trash(%__MODULE__{} = entity_data, opts) when is_list(opts) do
+    # Stash the row's current status in metadata so restore can return
+    # to it. Without this, restore unconditionally lands on "published"
+    # and a trashed draft silently goes live on restore.
+    metadata =
+      (entity_data.metadata || %{})
+      |> Map.put("trashed_from_status", entity_data.status)
+
     entity_data
-    |> changeset(%{status: @soft_delete_status})
+    |> status_only_changeset(@soft_delete_status, metadata)
     |> repo().update()
     |> notify_data_event(:trashed, opts)
   end
@@ -1386,30 +1394,57 @@ defmodule PhoenixKitEntities.EntityData do
   def trash(%__MODULE__{} = entity_data), do: trash(entity_data, [])
 
   @doc """
-  Restores a trashed entity data record by setting its status back to
-  `"published"`.
+  Restores a trashed entity data record. The status it returns to is
+  the one stashed in `metadata["trashed_from_status"]` when the row was
+  trashed — defaulting to `"draft"` if no stash is present (e.g. for
+  rows trashed via `bulk_trash/2`, or rows trashed before this stash
+  shipped).
 
   Returns `{:error, :not_trashed}` if the record isn't currently trashed —
-  this is a guardrail against re-publishing arbitrary records via the
-  trash-restore path. Use `update/2` for general status changes.
+  guardrail against re-publishing arbitrary records via the trash-restore
+  path. Use `update/2` for general status changes.
 
   ## Examples
 
       iex> EntityData.restore_from_trash(trashed_record, actor_uuid: admin.uuid)
-      {:ok, %EntityData{status: "published"}}
+      {:ok, %EntityData{status: "published"}}  # was published before trashing
   """
   @spec restore_from_trash(t(), keyword()) ::
           {:ok, t()} | {:error, :not_trashed | Ecto.Changeset.t()}
   def restore_from_trash(entity_data, opts \\ [])
 
   def restore_from_trash(%__MODULE__{status: @soft_delete_status} = entity_data, opts) do
+    prior_status =
+      case entity_data.metadata do
+        %{"trashed_from_status" => s} when s in @valid_statuses and s != @soft_delete_status -> s
+        _ -> "draft"
+      end
+
+    metadata = (entity_data.metadata || %{}) |> Map.delete("trashed_from_status")
+
     entity_data
-    |> changeset(%{status: "published"})
+    |> status_only_changeset(prior_status, metadata)
     |> repo().update()
     |> notify_data_event(:restored, opts)
   end
 
   def restore_from_trash(%__MODULE__{}, _opts), do: {:error, :not_trashed}
+
+  # Focused changeset for trash / restore — only touches `:status`,
+  # `:metadata`, and `:date_updated`. Skips the full per-field validation
+  # against the entity blueprint because a record whose `:data` is no
+  # longer valid (e.g. the entity gained a required field after the row
+  # was created) must still be retirable via trash. The bulk paths
+  # bypass changesets entirely; this keeps single-record + bulk in sync.
+  defp status_only_changeset(entity_data, status, metadata) do
+    entity_data
+    |> cast(%{status: status, metadata: metadata, date_updated: UtilsDate.utc_now()}, [
+      :status,
+      :metadata,
+      :date_updated
+    ])
+    |> validate_inclusion(:status, @valid_statuses)
+  end
 
   # Match Postgres FK / NOT NULL violations raised when a parent-app row
   # still references this record. SQLSTATE codes are stable: `23503` =
@@ -1789,8 +1824,8 @@ defmodule PhoenixKitEntities.EntityData do
 
   ## Performance — pass `entity` when the caller already has it
 
-  The single-arg form preloads `:entity` on every call. When rendering
-  many records (e.g. the admin trash bin), pass the already-loaded
+  The single-arg form preloads `:entity` on every call. Parent-app
+  callers rendering many records in a loop can pass the already-loaded
   entity as the second arg to skip the per-call N+1:
 
       entity = Entities.get_entity!(entity_uuid)
@@ -1848,7 +1883,17 @@ defmodule PhoenixKitEntities.EntityData do
         count = fun.(entity_data.uuid)
         if is_integer(count) and count >= 0, do: acc + count, else: acc
       rescue
-        _ -> acc
+        # Narrow to the DB-availability shapes — bugs in the parent-app
+        # callback (KeyError, FunctionClauseError, etc.) should surface
+        # in logs instead of silently zeroing the count. A broken
+        # callback that reports "Used by 0 rows" is the surprising
+        # default this guard was supposed to prevent.
+        e in [DBConnection.ConnectionError, Postgrex.Error] ->
+          Logger.warning(
+            "[Entities] reverse_references callback failed: #{Exception.message(e)}"
+          )
+
+          acc
       end
     end)
   end
@@ -1941,18 +1986,11 @@ defmodule PhoenixKitEntities.EntityData do
   end
 
   defp do_bulk_delete(uuids, opts) do
-    txn =
-      repo().transaction(fn ->
-        # Null trashed children of any row in the input set before
-        # deleting, so the self-FK doesn't block. Live external
-        # children would have tripped `has_external_live_children?/1`.
-        nullify_trashed_children(uuids)
-
-        from(d in __MODULE__, where: d.uuid in ^uuids)
-        |> repo().delete_all()
-      end)
-
-    case txn do
+    # Wrap ONLY the transaction in the rescue so an `ActivityLog.log`
+    # failure can't be misclassified as `:referenced_by_external`. The
+    # transaction itself returns `{:error, _}` on rollback; raised
+    # Postgrex errors are the FK / NOT NULL paths.
+    case run_bulk_delete_txn(uuids) do
       {:ok, {count, _} = result} ->
         PhoenixKitEntities.ActivityLog.log(%{
           action: "entity_data.bulk_deleted",
@@ -1971,10 +2009,21 @@ defmodule PhoenixKitEntities.EntityData do
         log_data_error_activity(:bulk_deleted, opts)
         {:error, :referenced_by_external}
     end
+  end
+
+  defp run_bulk_delete_txn(uuids) do
+    repo().transaction(fn ->
+      # Null trashed children of any row in the input set before
+      # deleting, so the self-FK doesn't block. Live external
+      # children would have tripped `has_external_live_children?/1`.
+      nullify_trashed_children(uuids)
+
+      from(d in __MODULE__, where: d.uuid in ^uuids)
+      |> repo().delete_all()
+    end)
   rescue
     e in Postgrex.Error ->
       if foreign_key_or_not_null_violation?(e) do
-        log_data_error_activity(:bulk_deleted, opts)
         {:error, :referenced_by_external}
       else
         reraise e, __STACKTRACE__

--- a/lib/phoenix_kit_entities/errors.ex
+++ b/lib/phoenix_kit_entities/errors.ex
@@ -46,6 +46,7 @@ defmodule PhoenixKitEntities.Errors do
           | :already_trashed
           | :not_trashed
           | :referenced_by_external
+          | :has_children
 
   @typedoc """
   Tagged tuples carrying interpolation context.
@@ -73,6 +74,12 @@ defmodule PhoenixKitEntities.Errors do
   def message(:referenced_by_external) do
     gettext(
       "Cannot permanently delete: this record is referenced by other tables in the parent application. Restore it or remove the references first."
+    )
+  end
+
+  def message(:has_children) do
+    gettext(
+      "Cannot permanently delete: this record has child records. Reassign or delete its children first."
     )
   end
 

--- a/lib/phoenix_kit_entities/web/data_form.ex
+++ b/lib/phoenix_kit_entities/web/data_form.ex
@@ -23,7 +23,12 @@ defmodule PhoenixKitEntities.Web.DataForm do
   alias PhoenixKitEntities.PresenceHelpers
 
   # Fields that should keep their primary-language DB column value on secondary tabs.
-  @preserve_fields %{"title" => :title, "slug" => :slug, "status" => :status}
+  @preserve_fields %{
+    "title" => :title,
+    "slug" => :slug,
+    "status" => :status,
+    "parent_uuid" => :parent_uuid
+  }
 
   @impl true
   def mount(_params, _session, socket) do
@@ -130,9 +135,38 @@ defmodule PhoenixKitEntities.Web.DataForm do
       |> assign(:form_record_topic_key, normalize_record_key(form_record_key))
       |> assign(:live_source, live_source)
       |> assign(:has_unsaved_changes, false)
+      |> assign_parent_options(entity, data_record, locale)
       |> mount_multilang()
 
     hydrate_data_presence(socket, entity, data_record, form_record_key, current_user)
+  end
+
+  # Build the parent-picker options for the current record. Excludes the
+  # row itself and any of its descendants (selecting either would create
+  # a cycle). Trashed rows are excluded — they can't meaningfully be a
+  # parent in the active tree.
+  defp assign_parent_options(socket, entity, data_record, locale) do
+    tree = EntityData.list_tree(entity.uuid, lang: locale)
+
+    excluded_uuids =
+      case data_record.uuid do
+        nil ->
+          MapSet.new()
+
+        uuid ->
+          [uuid | EntityData.descendant_uuids(uuid, entity.uuid)]
+          |> MapSet.new()
+      end
+
+    options =
+      tree
+      |> Enum.reject(&MapSet.member?(excluded_uuids, &1.record.uuid))
+      |> Enum.map(fn %{record: r, depth: d} ->
+        prefix = String.duplicate("— ", d)
+        {prefix <> (r.title || ""), r.uuid}
+      end)
+
+    assign(socket, :parent_options, options)
   end
 
   defp hydrate_data_presence(socket, entity, data_record, form_record_key, current_user) do
@@ -313,6 +347,25 @@ defmodule PhoenixKitEntities.Web.DataForm do
       %{uuid: uuid} -> uuid
       _ -> nil
     end
+  end
+
+  # The parent picker is rendered as a raw <select>, so any changeset
+  # error on :parent_uuid doesn't surface through <.input>'s built-in
+  # error block. Pull the first error message manually for the template.
+  defp parent_uuid_error(%Ecto.Changeset{action: action, errors: errors})
+       when action in [:validate, :insert, :update] do
+    case Keyword.get(errors, :parent_uuid) do
+      {msg, opts} -> translate_validator_error({msg, opts})
+      _ -> nil
+    end
+  end
+
+  defp parent_uuid_error(_), do: nil
+
+  defp translate_validator_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {k, v}, acc ->
+      String.replace(acc, "%{#{k}}", to_string(v))
+    end)
   end
 
   # ── Validate/Save helpers (below all handle_event clauses to avoid grouping warnings) ──
@@ -1321,7 +1374,7 @@ defmodule PhoenixKitEntities.Web.DataForm do
                   {gettext("Record Settings")}
                 </h2>
 
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
                   <%!-- Status --%>
                   <div>
                     <.label for="phoenix_kit_entity_data_status">{gettext("Status")}</.label>
@@ -1350,6 +1403,35 @@ defmodule PhoenixKitEntities.Web.DataForm do
                         </option>
                       </select>
                     </label>
+                  </div>
+
+                  <%!-- Parent (optional, same-entity) --%>
+                  <div>
+                    <.label for="phoenix_kit_entity_data_parent_uuid">{gettext("Parent")}</.label>
+                    <label class="select w-full">
+                      <select
+                        id="phoenix_kit_entity_data_parent_uuid"
+                        name="phoenix_kit_entity_data[parent_uuid]"
+                        disabled={@readonly?}
+                      >
+                        <option value="" selected={
+                          is_nil(Ecto.Changeset.get_field(@changeset, :parent_uuid))
+                        }>
+                          {gettext("— None (top level) —")}
+                        </option>
+                        <%= for {label, value} <- @parent_options do %>
+                          <option
+                            value={value}
+                            selected={Ecto.Changeset.get_field(@changeset, :parent_uuid) == value}
+                          >
+                            {label}
+                          </option>
+                        <% end %>
+                      </select>
+                    </label>
+                    <%= if (msg = parent_uuid_error(@changeset)) do %>
+                      <p class="mt-1 text-sm text-error">{msg}</p>
+                    <% end %>
                   </div>
 
                   <%!-- Entity Type (Read-only) --%>

--- a/lib/phoenix_kit_entities/web/data_form.ex
+++ b/lib/phoenix_kit_entities/web/data_form.ex
@@ -1541,6 +1541,35 @@ defmodule PhoenixKitEntities.Web.DataForm do
                     </label>
                   </div>
 
+                  <%!-- Parent (optional, same-entity) --%>
+                  <div>
+                    <.label for="phoenix_kit_entity_data_parent_uuid">{gettext("Parent")}</.label>
+                    <label class="select w-full">
+                      <select
+                        id="phoenix_kit_entity_data_parent_uuid"
+                        name="phoenix_kit_entity_data[parent_uuid]"
+                        disabled={@readonly?}
+                      >
+                        <option value="" selected={
+                          is_nil(Ecto.Changeset.get_field(@changeset, :parent_uuid))
+                        }>
+                          {gettext("— None (top level) —")}
+                        </option>
+                        <%= for {label, value} <- @parent_options do %>
+                          <option
+                            value={value}
+                            selected={Ecto.Changeset.get_field(@changeset, :parent_uuid) == value}
+                          >
+                            {label}
+                          </option>
+                        <% end %>
+                      </select>
+                    </label>
+                    <%= if (msg = parent_uuid_error(@changeset)) do %>
+                      <p class="mt-1 text-sm text-error">{msg}</p>
+                    <% end %>
+                  </div>
+
                   <%!-- Entity Type (Read-only) --%>
                   <div>
                     <.label>{gettext("Entity Type")}</.label>

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -310,12 +310,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
            socket
            |> refresh_data_stats()
            |> apply_filters()
-           |> put_flash(
-             :info,
-             gettext("Record moved to trash. Restore it before %{days} days to keep it.",
-               days: 90
-             )
-           )}
+           |> put_flash(:info, gettext("Record moved to trash. Restore from the trash view."))}
 
         {:error, :already_trashed} ->
           {:noreply, put_flash(socket, :info, gettext("Record is already in the trash"))}
@@ -364,6 +359,9 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
            |> put_flash(:info, gettext("Record permanently deleted"))}
 
         {:error, :referenced_by_external} ->
+          # No `refresh_data_stats` / `apply_filters` here — nothing
+          # changed in the DB. The single-select stays unchanged so
+          # the user can adjust references in the parent app and retry.
           {:noreply,
            put_flash(socket, :error, PhoenixKitEntities.Errors.message(:referenced_by_external))}
 
@@ -380,13 +378,17 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
       data_record = EntityData.get!(uuid)
 
       # Trashed records are excluded from the cycle — restore them
-      # explicitly via the dedicated Restore button instead.
+      # explicitly via the dedicated Restore button instead. The UI
+      # hides the toggle button for trashed rows so this case clause
+      # is unreachable in practice; the catch-all keeps the function
+      # total so an out-of-band call (stale browser tab, custom client)
+      # is a silent no-op rather than a `CaseClauseError`.
       new_status =
         case data_record.status do
           "draft" -> "published"
           "published" -> "archived"
           "archived" -> "draft"
-          "trashed" -> "trashed"
+          _ -> data_record.status
         end
 
       case EntityData.update_data(data_record, %{status: new_status}, actor_opts(socket)) do
@@ -604,6 +606,10 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
          |> put_flash(:info, gettext("%{count} records permanently deleted", count: count))}
 
       {:error, :referenced_by_external} ->
+        # No `assign(:selected_uuids, MapSet.new())` here — the bulk
+        # delete rolled back. Keeping the selection lets the user
+        # remove the FK-referenced rows from the multi-select and
+        # retry without re-checking each box.
         {:noreply,
          put_flash(socket, :error, PhoenixKitEntities.Errors.message(:referenced_by_external))}
     end

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -52,6 +52,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
       |> assign(:search_term, "")
       |> assign(:view_mode, "table")
       |> assign(:entity_data_records, [])
+      |> assign(:record_depths, %{})
 
     {:ok, socket}
   end
@@ -410,17 +411,25 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     end
   end
 
-  def handle_event("reorder_records", %{"ordered_ids" => ordered_ids}, socket)
+  def handle_event("reorder_records", %{"ordered_ids" => ordered_ids} = params, socket)
       when is_list(ordered_ids) do
+    # `moved_id` rides along on the JS side — push it back as a
+    # `sortable:flash` so the SortableGrid hook flashes the dropped
+    # row green on success / red on failure.
+    moved_id = params["moved_id"]
+
     cond do
       not Scope.admin?(socket.assigns.phoenix_kit_current_scope) ->
-        {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+        {:noreply,
+         socket
+         |> put_flash(:error, gettext("Not authorized"))
+         |> push_event("sortable:flash", %{uuid: moved_id, status: "error"})}
 
       is_nil(socket.assigns.selected_entity) or is_nil(socket.assigns.selected_entity_uuid) ->
         {:noreply, socket}
 
       true ->
-        apply_record_reorder(socket, ordered_ids)
+        apply_record_reorder(socket, ordered_ids, moved_id)
     end
   end
 
@@ -600,7 +609,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
     end
   end
 
-  defp apply_record_reorder(socket, ordered_ids) do
+  defp apply_record_reorder(socket, ordered_ids, moved_id) do
     {entity, sort_flipped?} = ensure_manual_sort(socket.assigns.selected_entity)
     entity_uuid = socket.assigns.selected_entity_uuid
 
@@ -610,6 +619,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
           socket
           |> assign(:selected_entity, entity)
           |> apply_filters()
+          |> push_event("sortable:flash", %{uuid: moved_id, status: "ok"})
 
         socket =
           if sort_flipped? == :failed do
@@ -627,7 +637,10 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
         {:noreply, socket}
 
       _ ->
-        {:noreply, put_flash(socket, :error, gettext("Failed to save the new order"))}
+        {:noreply,
+         socket
+         |> put_flash(:error, gettext("Failed to save the new order"))
+         |> push_event("sortable:flash", %{uuid: moved_id, status: "error"})}
     end
   end
 
@@ -790,11 +803,49 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
         do: [sort_mode: Entities.get_sort_mode(entity), lang: socket.assigns[:current_locale]],
         else: [lang: socket.assigns[:current_locale]]
 
-    entity_data_records =
+    raw_records =
       fetch_records(entity_uuid, status, sort_opts)
       |> filter_by_search(search_term)
 
-    assign(socket, :entity_data_records, entity_data_records)
+    {records, depths} = maybe_tree_order(raw_records, entity_uuid, status, search_term)
+
+    socket
+    |> assign(:entity_data_records, records)
+    |> assign(:record_depths, depths)
+  end
+
+  # Tree-order rows only when the view is showing a coherent slice of
+  # one entity. A status filter or a search term carves the set in
+  # half, leaving parents pointing at rows that aren't in the result —
+  # in that case fall back to flat sibling order and zero depths so
+  # the template renders without indentation.
+  defp maybe_tree_order(records, entity_uuid, "all", "")
+       when is_binary(entity_uuid) and records != [] do
+    {tree_records, depth_map} = tree_order(records)
+    {tree_records, depth_map}
+  end
+
+  defp maybe_tree_order(records, _entity_uuid, _status, _search) do
+    {records, %{}}
+  end
+
+  defp tree_order(rows) do
+    known = MapSet.new(rows, & &1.uuid)
+    by_parent = Enum.group_by(rows, & &1.parent_uuid)
+
+    roots =
+      Enum.filter(rows, fn row ->
+        is_nil(row.parent_uuid) or not MapSet.member?(known, row.parent_uuid)
+      end)
+
+    flat = Enum.flat_map(roots, &walk_for_navigator(&1, by_parent, 0))
+    depths = Map.new(flat, fn {row, d} -> {row.uuid, d} end)
+    {Enum.map(flat, &elem(&1, 0)), depths}
+  end
+
+  defp walk_for_navigator(row, by_parent, depth) do
+    children = Map.get(by_parent, row.uuid, [])
+    [{row, depth} | Enum.flat_map(children, &walk_for_navigator(&1, by_parent, depth + 1))]
   end
 
   # When an entity is selected, use sort-mode-aware queries
@@ -1409,7 +1460,9 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                   <% end %>
                   <.table_default_header_cell>{gettext("Status")}</.table_default_header_cell>
                   <.table_default_header_cell>{gettext("Created")}</.table_default_header_cell>
-                  <.table_default_header_cell>{gettext("Actions")}</.table_default_header_cell>
+                  <.table_default_header_cell class="w-px whitespace-nowrap text-right">
+                    {gettext("Actions")}
+                  </.table_default_header_cell>
                 </.table_default_row>
               </.table_default_header>
               <tbody
@@ -1418,6 +1471,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                 data-sortable-event="reorder_records"
                 data-sortable-items=".sortable-item"
                 data-sortable-hide-source="false"
+                data-sortable-handle=".pk-drag-handle"
                 phx-hook={if @selected_entity, do: "SortableGrid"}
               >
                 <%= for data_record <- @entity_data_records do %>
@@ -1427,7 +1481,8 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                   >
                     <.table_default_cell
                       :if={@selected_entity && length(@entity_data_records) > 1}
-                      class="cursor-grab active:cursor-grabbing text-base-content/40"
+                      class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 transition-colors"
+                      title={gettext("Drag to reorder")}
                     >
                       <.icon name="hero-bars-3" class="w-4 h-4" />
                     </.table_default_cell>
@@ -1449,7 +1504,12 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                         }
                         class="block hover:text-primary transition-colors cursor-pointer"
                       >
-                        <div class="font-bold">{data_record.title}</div>
+                        <div class="font-bold">
+                          <%= if (depth = Map.get(@record_depths, data_record.uuid, 0)) > 0 do %>
+                            <span class="opacity-60 mr-1">{String.duplicate("— ", depth)}</span>
+                          <% end %>
+                          {data_record.title}
+                        </div>
                         <%= if data_record.slug do %>
                           <div class="text-sm opacity-50">
                             <.icon name="hero-link" class="w-3 h-3 inline" />
@@ -1481,103 +1541,80 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
                         </div>
                       <% end %>
                     </.table_default_cell>
-                    <.table_default_cell>
-                      <div class="flex gap-2">
-                        <.link
+                    <.table_default_cell class="text-right whitespace-nowrap">
+                      <.table_row_menu mode="auto" id={"data-menu-#{data_record.uuid}"}>
+                        <.table_row_menu_link
                           navigate={
                             PhoenixKit.Utils.Routes.path(
                               "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}"
                             )
                           }
-                          class="btn btn-outline btn-xs tooltip tooltip-bottom"
-                          data-tip={gettext("View")}
-                        >
-                          <.icon name="hero-eye" class="w-4 h-4 hidden sm:inline" />
-                          <span class="sm:hidden whitespace-nowrap">{gettext("View")}</span>
-                        </.link>
-                        <.link
+                          icon="hero-eye"
+                          label={gettext("View")}
+                        />
+                        <.table_row_menu_link
                           navigate={
                             PhoenixKit.Utils.Routes.path(
                               "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}/edit"
                             )
                           }
-                          class="btn btn-outline btn-xs tooltip tooltip-bottom"
-                          data-tip={gettext("Edit")}
-                        >
-                          <.icon name="hero-pencil" class="w-4 h-4 hidden sm:inline" />
-                          <span class="sm:hidden whitespace-nowrap">{gettext("Edit")}</span>
-                        </.link>
+                          icon="hero-pencil"
+                          label={gettext("Edit")}
+                        />
+                        <.table_row_menu_divider />
                         <%= cond do %>
                           <% data_record.status == "trashed" -> %>
-                            <button
-                              class="btn btn-outline btn-xs text-success tooltip tooltip-bottom"
+                            <.table_row_menu_button
                               phx-click="restore_from_trash"
                               phx-value-uuid={data_record.uuid}
                               phx-disable-with={gettext("…")}
-                              data-tip={gettext("Restore from trash")}
-                            >
-                              <.icon name="hero-arrow-uturn-left" class="w-4 h-4 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Restore")}</span>
-                            </button>
-                            <button
-                              class="btn btn-outline btn-xs text-error tooltip tooltip-bottom"
+                              icon="hero-arrow-uturn-left"
+                              label={gettext("Restore from trash")}
+                            />
+                            <.table_row_menu_button
                               phx-click="permanent_delete"
                               phx-value-uuid={data_record.uuid}
                               phx-disable-with={gettext("…")}
-                              data-tip={gettext("Delete forever")}
                               data-confirm={
                                 gettext(
                                   "Permanently delete this record? This cannot be undone, and will fail if it's still referenced by other tables."
                                 )
                               }
-                            >
-                              <.icon name="hero-x-circle" class="w-4 h-4 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Delete")}</span>
-                            </button>
+                              icon="hero-x-circle"
+                              label={gettext("Delete forever")}
+                            />
                           <% data_record.status == "archived" -> %>
-                            <button
-                              class="btn btn-outline btn-xs text-success tooltip tooltip-bottom"
+                            <.table_row_menu_button
                               phx-click="restore_data"
                               phx-value-uuid={data_record.uuid}
                               phx-disable-with={gettext("…")}
-                              data-tip={gettext("Restore")}
-                            >
-                              <.icon name="hero-arrow-path" class="w-4 h-4 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Restore")}</span>
-                            </button>
-                            <button
-                              class="btn btn-outline btn-xs text-error tooltip tooltip-bottom"
+                              icon="hero-arrow-path"
+                              label={gettext("Restore")}
+                            />
+                            <.table_row_menu_button
                               phx-click="trash_data"
                               phx-value-uuid={data_record.uuid}
                               phx-disable-with={gettext("…")}
-                              data-tip={gettext("Move to trash")}
-                            >
-                              <.icon name="hero-trash" class="w-4 h-4 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Trash")}</span>
-                            </button>
+                              icon="hero-trash"
+                              label={gettext("Move to trash")}
+                            />
                           <% true -> %>
-                            <button
-                              class="btn btn-outline btn-xs text-warning tooltip tooltip-bottom"
+                            <.table_row_menu_button
                               phx-click="archive_data"
                               phx-value-uuid={data_record.uuid}
                               phx-disable-with={gettext("…")}
-                              data-tip={gettext("Archive")}
-                            >
-                              <.icon name="hero-archive-box" class="w-4 h-4 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Archive")}</span>
-                            </button>
-                            <button
-                              class="btn btn-outline btn-xs text-error tooltip tooltip-bottom"
+                              icon="hero-archive-box"
+                              label={gettext("Archive")}
+                            />
+                            <.table_row_menu_button
                               phx-click="trash_data"
                               phx-value-uuid={data_record.uuid}
                               phx-disable-with={gettext("…")}
-                              data-tip={gettext("Move to trash")}
-                            >
-                              <.icon name="hero-trash" class="w-4 h-4 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Trash")}</span>
-                            </button>
+                              icon="hero-trash"
+                              label={gettext("Move to trash")}
+                            />
                         <% end %>
-                      </div>
+                      </.table_row_menu>
                     </.table_default_cell>
                   </.table_default_row>
                 <% end %>
@@ -1591,16 +1628,17 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
               item_id={&(&1.uuid)}
               on_reorder="reorder_records"
               draggable={not is_nil(@selected_entity) and length(@entity_data_records) > 1}
+              sortable_handle=".pk-drag-handle"
               layout={:list}
               gap="gap-6"
             >
               <:item :let={data_record}>
-                <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow">
+                <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow group/card">
                 <div class="card-body">
                   <div class="flex items-start gap-3 mb-4">
                     <div
                       :if={@selected_entity && length(@entity_data_records) > 1}
-                      class="cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 mt-1"
+                      class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/0 group-hover/card:text-base-content/50 transition-colors mt-1"
                       title={gettext("Drag to reorder")}
                     >
                       <.icon name="hero-bars-3" class="w-5 h-5" />
@@ -1695,92 +1733,79 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
 
                   <%!-- Actions --%>
                   <div class="card-actions justify-end">
-                    <.link
-                      navigate={
-                        PhoenixKit.Utils.Routes.path(
-                          "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}"
-                        )
-                      }
-                      class="btn btn-outline btn-sm"
-                    >
-                      <.icon name="hero-eye" class="w-4 h-4 mr-1" /> {gettext("View")}
-                    </.link>
-                    <.link
-                      navigate={
-                        PhoenixKit.Utils.Routes.path(
-                          "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}/edit"
-                        )
-                      }
-                      class="btn btn-primary btn-sm"
-                    >
-                      <.icon name="hero-pencil" class="w-4 h-4 mr-1" /> {gettext("Edit")}
-                    </.link>
-
-                    <%!-- Archive / Trash / Restore / Permanent-delete buttons --%>
-                    <%= cond do %>
-                      <% data_record.status == "trashed" -> %>
-                        <button
-                          class="btn btn-success btn-sm"
-                          phx-click="restore_from_trash"
-                          phx-value-uuid={data_record.uuid}
-                          phx-disable-with={gettext("…")}
-                          title={gettext("Restore from trash")}
-                        >
-                          <.icon name="hero-arrow-uturn-left" class="w-4 h-4" />
-                        </button>
-                        <button
-                          class="btn btn-error btn-sm"
-                          phx-click="permanent_delete"
-                          phx-value-uuid={data_record.uuid}
-                          phx-disable-with={gettext("…")}
-                          title={gettext("Delete forever")}
-                          data-confirm={
-                            gettext(
-                              "Permanently delete this record? This cannot be undone, and will fail if it's still referenced by other tables."
-                            )
-                          }
-                        >
-                          <.icon name="hero-x-circle" class="w-4 h-4" />
-                        </button>
-                      <% data_record.status == "archived" -> %>
-                        <button
-                          class="btn btn-success btn-sm"
-                          phx-click="restore_data"
-                          phx-value-uuid={data_record.uuid}
-                          phx-disable-with={gettext("…")}
-                          title={gettext("Restore data record")}
-                        >
-                          <.icon name="hero-arrow-path" class="w-4 h-4" />
-                        </button>
-                        <button
-                          class="btn btn-error btn-sm"
-                          phx-click="trash_data"
-                          phx-value-uuid={data_record.uuid}
-                          phx-disable-with={gettext("…")}
-                          title={gettext("Move to trash")}
-                        >
-                          <.icon name="hero-trash" class="w-4 h-4" />
-                        </button>
-                      <% true -> %>
-                        <button
-                          class="btn btn-warning btn-sm"
-                          phx-click="archive_data"
-                          phx-value-uuid={data_record.uuid}
-                          phx-disable-with={gettext("…")}
-                          title={gettext("Archive data record")}
-                        >
-                          <.icon name="hero-archive-box" class="w-4 h-4" />
-                        </button>
-                        <button
-                          class="btn btn-error btn-sm"
-                          phx-click="trash_data"
-                          phx-value-uuid={data_record.uuid}
-                          phx-disable-with={gettext("…")}
-                          title={gettext("Move to trash")}
-                        >
-                          <.icon name="hero-trash" class="w-4 h-4" />
-                        </button>
-                    <% end %>
+                    <.table_row_menu mode="auto" id={"data-card-menu-#{data_record.uuid}"}>
+                      <.table_row_menu_link
+                        navigate={
+                          PhoenixKit.Utils.Routes.path(
+                            "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}"
+                          )
+                        }
+                        icon="hero-eye"
+                        label={gettext("View")}
+                      />
+                      <.table_row_menu_link
+                        navigate={
+                          PhoenixKit.Utils.Routes.path(
+                            "/admin/entities/#{get_entity_slug(@entities, data_record.entity_uuid)}/data/#{data_record.uuid}/edit"
+                          )
+                        }
+                        icon="hero-pencil"
+                        label={gettext("Edit")}
+                      />
+                      <.table_row_menu_divider />
+                      <%= cond do %>
+                        <% data_record.status == "trashed" -> %>
+                          <.table_row_menu_button
+                            phx-click="restore_from_trash"
+                            phx-value-uuid={data_record.uuid}
+                            phx-disable-with={gettext("…")}
+                            icon="hero-arrow-uturn-left"
+                            label={gettext("Restore from trash")}
+                          />
+                          <.table_row_menu_button
+                            phx-click="permanent_delete"
+                            phx-value-uuid={data_record.uuid}
+                            phx-disable-with={gettext("…")}
+                            data-confirm={
+                              gettext(
+                                "Permanently delete this record? This cannot be undone, and will fail if it's still referenced by other tables."
+                              )
+                            }
+                            icon="hero-x-circle"
+                            label={gettext("Delete forever")}
+                          />
+                        <% data_record.status == "archived" -> %>
+                          <.table_row_menu_button
+                            phx-click="restore_data"
+                            phx-value-uuid={data_record.uuid}
+                            phx-disable-with={gettext("…")}
+                            icon="hero-arrow-path"
+                            label={gettext("Restore")}
+                          />
+                          <.table_row_menu_button
+                            phx-click="trash_data"
+                            phx-value-uuid={data_record.uuid}
+                            phx-disable-with={gettext("…")}
+                            icon="hero-trash"
+                            label={gettext("Move to trash")}
+                          />
+                        <% true -> %>
+                          <.table_row_menu_button
+                            phx-click="archive_data"
+                            phx-value-uuid={data_record.uuid}
+                            phx-disable-with={gettext("…")}
+                            icon="hero-archive-box"
+                            label={gettext("Archive")}
+                          />
+                          <.table_row_menu_button
+                            phx-click="trash_data"
+                            phx-value-uuid={data_record.uuid}
+                            phx-disable-with={gettext("…")}
+                            icon="hero-trash"
+                            label={gettext("Move to trash")}
+                          />
+                      <% end %>
+                    </.table_row_menu>
                   </div>
                 </div>
               </div>

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -365,6 +365,10 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
           {:noreply,
            put_flash(socket, :error, PhoenixKitEntities.Errors.message(:referenced_by_external))}
 
+        {:error, :has_children} ->
+          {:noreply,
+           put_flash(socket, :error, PhoenixKitEntities.Errors.message(:has_children))}
+
         {:error, _} ->
           {:noreply, put_flash(socket, :error, gettext("Failed to delete record"))}
       end
@@ -612,6 +616,10 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
         # retry without re-checking each box.
         {:noreply,
          put_flash(socket, :error, PhoenixKitEntities.Errors.message(:referenced_by_external))}
+
+      {:error, :has_children} ->
+        {:noreply,
+         put_flash(socket, :error, PhoenixKitEntities.Errors.message(:has_children))}
     end
   end
 

--- a/lib/phoenix_kit_entities/web/entities.ex
+++ b/lib/phoenix_kit_entities/web/entities.ex
@@ -105,30 +105,44 @@ defmodule PhoenixKitEntities.Web.Entities do
     end
   end
 
-  def handle_event("reorder_entities", %{"ordered_ids" => ordered_ids}, socket)
+  def handle_event("reorder_entities", %{"ordered_ids" => ordered_ids} = params, socket)
       when is_list(ordered_ids) do
+    # `moved_id` rides along on the JS side — push it back as a
+    # `sortable:flash` so the SortableGrid hook flashes the dropped
+    # row green on success / red on failure. Matches the
+    # `phoenix_kit_projects` reorder convention.
+    moved_id = params["moved_id"]
+
     if Scope.admin?(socket.assigns.phoenix_kit_current_scope) do
       case Entities.reorder_entities(ordered_ids, actor_opts(socket)) do
         :ok ->
           {:noreply,
-           assign(
-             socket,
+           socket
+           |> assign(
              :entities,
              Entities.list_entities(lang: socket.assigns[:current_locale])
-           )}
+           )
+           |> push_event("sortable:flash", %{uuid: moved_id, status: "ok"})}
 
         {:error, _reason} ->
-          {:noreply, put_flash(socket, :error, gettext("Failed to save the new order"))}
+          {:noreply,
+           socket
+           |> put_flash(:error, gettext("Failed to save the new order"))
+           |> push_event("sortable:flash", %{uuid: moved_id, status: "error"})}
       end
     else
-      {:noreply, put_flash(socket, :error, gettext("Not authorized"))}
+      {:noreply,
+       socket
+       |> put_flash(:error, gettext("Not authorized"))
+       |> push_event("sortable:flash", %{uuid: moved_id, status: "error"})}
     end
   end
 
   # Defensive catch-all: a stale browser tab or a custom client could
   # push a malformed `reorder_entities` payload (missing `ordered_ids`
   # or wrong type). Flash + no-op rather than crash the LV socket
-  # with a MatchError.
+  # with a MatchError. No `sortable:flash` here — without a `moved_id`
+  # the hook can't key the highlight to a row anyway.
   def handle_event("reorder_entities", _params, socket) do
     {:noreply, put_flash(socket, :error, gettext("Failed to save the new order"))}
   end
@@ -255,7 +269,9 @@ defmodule PhoenixKitEntities.Web.Entities do
                     <.table_default_header_cell>{gettext("Status")}</.table_default_header_cell>
                     <.table_default_header_cell>{gettext("Fields")}</.table_default_header_cell>
                     <.table_default_header_cell>{gettext("Created")}</.table_default_header_cell>
-                    <.table_default_header_cell>{gettext("Actions")}</.table_default_header_cell>
+                    <.table_default_header_cell class="w-px whitespace-nowrap text-right">
+                      {gettext("Actions")}
+                    </.table_default_header_cell>
                   </.table_default_row>
                 </.table_default_header>
                 <tbody
@@ -264,13 +280,15 @@ defmodule PhoenixKitEntities.Web.Entities do
                   data-sortable-event="reorder_entities"
                   data-sortable-items=".sortable-item"
                   data-sortable-hide-source="false"
+                  data-sortable-handle=".pk-drag-handle"
                   phx-hook="SortableGrid"
                 >
                   <%= for entity <- @entities do %>
                     <.table_default_row class="sortable-item" data-id={entity.uuid}>
                       <.table_default_cell
                         :if={length(@entities) > 1}
-                        class="cursor-grab active:cursor-grabbing text-base-content/40"
+                        class="pk-drag-handle cursor-grab active:cursor-grabbing text-base-content/30 hover:text-base-content/70 transition-colors"
+                        title={gettext("Drag to reorder")}
                       >
                         <.icon name="hero-bars-3" class="w-4 h-4" />
                       </.table_default_cell>
@@ -323,55 +341,44 @@ defmodule PhoenixKitEntities.Web.Entities do
                           {PhoenixKit.Utils.Date.format_date_with_user_format(entity.date_created)}
                         </span>
                       </.table_default_cell>
-                      <.table_default_cell>
-                        <div class="flex gap-2">
-                          <.link
+                      <.table_default_cell class="text-right whitespace-nowrap">
+                        <.table_row_menu mode="auto" id={"entity-menu-#{entity.uuid}"}>
+                          <.table_row_menu_link
                             navigate={
                               PhoenixKit.Utils.Routes.locale_aware_path(
                                 assigns,
                                 "/admin/entities/#{entity.name}/data"
                               )
                             }
-                            class="btn btn-xs btn-outline btn-info tooltip tooltip-bottom"
-                            data-tip={gettext("Go to Data")}
-                          >
-                            <.icon name="hero-arrow-right" class="w-4 h-4 hidden sm:inline" />
-                            <span class="sm:hidden whitespace-nowrap">{gettext("Go to Data")}</span>
-                          </.link>
-                          <.link
+                            icon="hero-arrow-right"
+                            label={gettext("Go to Data")}
+                          />
+                          <.table_row_menu_link
                             navigate={
                               PhoenixKit.Utils.Routes.path("/admin/entities/#{entity.uuid}/edit")
                             }
-                            class="btn btn-xs btn-outline btn-info tooltip tooltip-bottom"
-                            data-tip={gettext("Edit")}
-                          >
-                            <.icon name="hero-pencil" class="w-4 h-4 hidden sm:inline" />
-                            <span class="sm:hidden whitespace-nowrap">{gettext("Edit")}</span>
-                          </.link>
+                            icon="hero-pencil"
+                            label={gettext("Edit")}
+                          />
+                          <.table_row_menu_divider />
                           <%= if entity.status == "archived" do %>
-                            <button
-                              class="btn btn-xs btn-outline btn-info tooltip tooltip-bottom text-success"
+                            <.table_row_menu_button
                               phx-click="restore_entity"
                               phx-value-uuid={entity.uuid}
                               phx-disable-with={gettext("…")}
-                              data-tip={gettext("Restore")}
-                            >
-                              <.icon name="hero-arrow-path" class="w-4 h-4 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Restore")}</span>
-                            </button>
+                              icon="hero-arrow-path"
+                              label={gettext("Restore")}
+                            />
                           <% else %>
-                            <button
-                              class="btn btn-xs btn-outline btn-info tooltip tooltip-bottom text-error"
+                            <.table_row_menu_button
                               phx-click="archive_entity"
                               phx-value-uuid={entity.uuid}
                               phx-disable-with={gettext("…")}
-                              data-tip={gettext("Archive")}
-                            >
-                              <.icon name="hero-trash" class="w-4 h-4 hidden sm:inline" />
-                              <span class="sm:hidden whitespace-nowrap">{gettext("Archive")}</span>
-                            </button>
+                              icon="hero-trash"
+                              label={gettext("Archive")}
+                            />
                           <% end %>
-                        </div>
+                        </.table_row_menu>
                       </.table_default_cell>
                     </.table_default_row>
                   <% end %>
@@ -388,13 +395,22 @@ defmodule PhoenixKitEntities.Web.Entities do
               item_id={&(&1.uuid)}
               on_reorder="reorder_entities"
               draggable={length(@entities) > 1}
+              sortable_handle=".pk-drag-handle"
               layout={:grid}
               cols={1}
               gap="gap-6"
               class="md:grid-cols-2 lg:grid-cols-3"
             >
               <:item :let={entity}>
-                <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow h-full">
+                <div class="card bg-base-100 shadow-xl hover:shadow-2xl transition-shadow h-full group/card relative">
+                  <%= if length(@entities) > 1 do %>
+                    <div
+                      class="pk-drag-handle absolute top-2 left-2 cursor-grab active:cursor-grabbing text-base-content/0 group-hover/card:text-base-content/50 transition-colors"
+                      title={gettext("Drag to reorder")}
+                    >
+                      <.icon name="hero-bars-3" class="w-5 h-5" />
+                    </div>
+                  <% end %>
                   <div class="card-body">
                     <div class="flex items-start justify-between mb-4">
                       <.link
@@ -450,41 +466,40 @@ defmodule PhoenixKitEntities.Web.Entities do
 
                     <%!-- Actions --%>
                     <div class="card-actions justify-end">
-                      <.link
-                        navigate={PhoenixKit.Utils.Routes.path("/admin/entities/#{entity.name}/data")}
-                        class="btn btn-outline btn-sm"
-                      >
-                        <.icon name="hero-arrow-right" class="w-4 h-4 mr-1" /> {gettext("Go to Data")}
-                      </.link>
-                      <.link
-                        navigate={PhoenixKit.Utils.Routes.path("/admin/entities/#{entity.uuid}/edit")}
-                        class="btn btn-primary btn-sm"
-                      >
-                        <.icon name="hero-pencil" class="w-4 h-4 mr-1" /> {gettext("Edit")}
-                      </.link>
-
-                      <%!-- Archive/Restore Button --%>
-                      <%= if entity.status == "archived" do %>
-                        <button
-                          class="btn btn-success btn-sm"
-                          phx-click="restore_entity"
-                          phx-value-uuid={entity.uuid}
-                          phx-disable-with={gettext("…")}
-                          title={gettext("Restore entity")}
-                        >
-                          <.icon name="hero-arrow-path" class="w-4 h-4" />
-                        </button>
-                      <% else %>
-                        <button
-                          class="btn btn-error btn-sm"
-                          phx-click="archive_entity"
-                          phx-value-uuid={entity.uuid}
-                          phx-disable-with={gettext("…")}
-                          title={gettext("Archive entity")}
-                        >
-                          <.icon name="hero-trash" class="w-4 h-4" />
-                        </button>
-                      <% end %>
+                      <.table_row_menu mode="auto" id={"entity-card-menu-#{entity.uuid}"}>
+                        <.table_row_menu_link
+                          navigate={
+                            PhoenixKit.Utils.Routes.path("/admin/entities/#{entity.name}/data")
+                          }
+                          icon="hero-arrow-right"
+                          label={gettext("Go to Data")}
+                        />
+                        <.table_row_menu_link
+                          navigate={
+                            PhoenixKit.Utils.Routes.path("/admin/entities/#{entity.uuid}/edit")
+                          }
+                          icon="hero-pencil"
+                          label={gettext("Edit")}
+                        />
+                        <.table_row_menu_divider />
+                        <%= if entity.status == "archived" do %>
+                          <.table_row_menu_button
+                            phx-click="restore_entity"
+                            phx-value-uuid={entity.uuid}
+                            phx-disable-with={gettext("…")}
+                            icon="hero-arrow-path"
+                            label={gettext("Restore")}
+                          />
+                        <% else %>
+                          <.table_row_menu_button
+                            phx-click="archive_entity"
+                            phx-value-uuid={entity.uuid}
+                            phx-disable-with={gettext("…")}
+                            icon="hero-trash"
+                            label={gettext("Archive")}
+                          />
+                        <% end %>
+                      </.table_row_menu>
                     </div>
 
                     <%!-- Created Date --%>

--- a/lib/phoenix_kit_entities/web/entity_form.ex
+++ b/lib/phoenix_kit_entities/web/entity_form.ex
@@ -32,24 +32,84 @@ defmodule PhoenixKitEntities.Web.EntityForm do
   def mount(_params, _session, socket) do
     # Defer DB query to handle_params/3 — mount runs twice (HTTP + WebSocket),
     # handle_params runs once. See Phoenix iron law.
-    {:ok, socket}
+    # Capture the page the user came from (WS connect only) so the
+    # "and Return" button can route back there. Validated as an
+    # internal admin path; falls back to the entities list otherwise.
+    return_to =
+      if connected?(socket) do
+        socket |> get_connect_params() |> referer_to_return_path()
+      end
+
+    {:ok, assign(socket, :return_to_path, return_to)}
   end
 
   @impl true
-  def handle_params(%{"id" => id} = _params, _uri, socket) do
+  def handle_params(%{"id" => id} = _params, uri, socket) do
     # Edit mode
     entity = Entities.get_entity!(id)
     changeset = Entities.change_entity(entity)
 
-    {:noreply, hydrate_entity_form(socket, entity, changeset, gettext("Edit Entity"))}
+    socket =
+      socket
+      |> drop_self_referer(uri)
+      |> hydrate_entity_form(entity, changeset, gettext("Edit Entity"))
+
+    {:noreply, socket}
   end
 
-  def handle_params(_params, _uri, socket) do
+  def handle_params(_params, uri, socket) do
     # Create mode
     entity = %Entities{}
     changeset = Entities.change_entity(entity)
 
-    {:noreply, hydrate_entity_form(socket, entity, changeset, gettext("New Entity"))}
+    socket =
+      socket
+      |> drop_self_referer(uri)
+      |> hydrate_entity_form(entity, changeset, gettext("New Entity"))
+
+    {:noreply, socket}
+  end
+
+  # Pull `_live_referer` out of the connect params, parse the path, and
+  # return it only if it looks like an internal admin path. External or
+  # malformed referrers fall back to nil so the save handler routes to
+  # the entities list. Defensive — never trust a redirect target that
+  # rides in on a client-supplied param.
+  defp referer_to_return_path(%{"_live_referer" => referer}) when is_binary(referer) do
+    case URI.parse(referer) do
+      %URI{path: path} when is_binary(path) ->
+        if internal_admin_path?(path), do: path, else: nil
+
+      _ ->
+        nil
+    end
+  end
+
+  defp referer_to_return_path(_), do: nil
+
+  # An "admin path" lives under <url_prefix>/.../admin/. We don't trust
+  # arbitrary site paths — only the admin area.
+  defp internal_admin_path?(path) do
+    String.starts_with?(path, "/") and String.contains?(path, "/admin")
+  end
+
+  # If the referrer is the same page we're rendering (e.g. user reloaded
+  # the edit page), drop it so "and Return" doesn't no-op back to here.
+  defp drop_self_referer(socket, uri) do
+    case socket.assigns[:return_to_path] do
+      nil ->
+        socket
+
+      path ->
+        current_path = URI.parse(uri).path
+
+        if current_path && String.trim_trailing(current_path, "/") ==
+             String.trim_trailing(path, "/") do
+          assign(socket, :return_to_path, nil)
+        else
+          socket
+        end
+    end
   end
 
   defp hydrate_entity_form(socket, entity, _changeset, page_title) do
@@ -185,9 +245,12 @@ defmodule PhoenixKitEntities.Web.EntityForm do
     end
   end
 
-  def handle_event("save", %{"entities" => entity_params}, socket) do
+  def handle_event("save", %{"entities" => entity_params} = params, socket) do
     if socket.assigns[:lock_owner?] do
-      do_save(entity_params, socket)
+      # "Create and Return" / "Update and Return" submits a second button
+      # named `return_to_list=true`; the regular Create/Update button omits it.
+      return_to_list? = params["return_to_list"] == "true"
+      do_save(entity_params, assign(socket, :return_to_list, return_to_list?))
     else
       {:noreply, put_flash(socket, :error, gettext("Cannot save - you are spectating"))}
     end
@@ -976,29 +1039,52 @@ defmodule PhoenixKitEntities.Web.EntityForm do
   end
 
   defp handle_save_success(socket, saved_entity) do
-    if socket.assigns.entity.uuid do
-      changeset = Entities.change_entity(saved_entity)
+    locale = socket.assigns[:current_locale] || "en"
 
-      socket =
-        socket
-        |> assign(:entity, saved_entity)
-        |> assign(:changeset, changeset)
-        |> assign(:fields, saved_entity.fields_definition || [])
-        |> assign(:sort_mode, Entities.get_sort_mode(saved_entity))
-        |> put_flash(:info, gettext("Entity saved successfully"))
+    cond do
+      socket.assigns[:return_to_list] ->
+        flash =
+          if socket.assigns.entity.uuid,
+            do: gettext("Entity saved successfully"),
+            else: gettext("Entity created successfully")
 
-      reply_with_broadcast(socket)
-    else
-      locale = socket.assigns[:current_locale] || "en"
+        # Prefer the page the user came from (captured at mount and
+        # validated as an internal admin path); fall back to the
+        # entities list. `Routes.path/2` already carries the URL prefix
+        # so the captured path is used as-is.
+        return_target =
+          socket.assigns[:return_to_path] ||
+            Routes.path("/admin/entities", locale: locale)
 
-      socket =
-        socket
-        |> put_flash(:info, gettext("Entity created successfully"))
-        |> push_navigate(
-          to: Routes.path("/admin/entities/#{saved_entity.uuid}/edit", locale: locale)
-        )
+        socket =
+          socket
+          |> put_flash(:info, flash)
+          |> push_navigate(to: return_target)
 
-      {:noreply, socket}
+        {:noreply, socket}
+
+      socket.assigns.entity.uuid ->
+        changeset = Entities.change_entity(saved_entity)
+
+        socket =
+          socket
+          |> assign(:entity, saved_entity)
+          |> assign(:changeset, changeset)
+          |> assign(:fields, saved_entity.fields_definition || [])
+          |> assign(:sort_mode, Entities.get_sort_mode(saved_entity))
+          |> put_flash(:info, gettext("Entity saved successfully"))
+
+        reply_with_broadcast(socket)
+
+      true ->
+        socket =
+          socket
+          |> put_flash(:info, gettext("Entity created successfully"))
+          |> push_navigate(
+            to: Routes.path("/admin/entities/#{saved_entity.uuid}/edit", locale: locale)
+          )
+
+        {:noreply, socket}
     end
   end
 
@@ -1679,14 +1765,26 @@ defmodule PhoenixKitEntities.Web.EntityForm do
           phx-submit="save"
           class="space-y-8"
         >
-          <div class="flex justify-end">
+          <div class="flex justify-end gap-2">
             <button
               type="submit"
-              class="btn btn-primary"
+              class="btn btn-primary btn-outline"
               disabled={!@changeset.valid? or @readonly?}
               phx-disable-with={gettext("Saving…")}
             >
               {if @entity.uuid, do: gettext("Update Entity"), else: gettext("Create Entity")}
+            </button>
+            <button
+              type="submit"
+              name="return_to_list"
+              value="true"
+              class="btn btn-primary"
+              disabled={!@changeset.valid? or @readonly?}
+              phx-disable-with={gettext("Saving…")}
+            >
+              {if @entity.uuid,
+                do: gettext("Update and Return"),
+                else: gettext("Create and Return")}
             </button>
           </div>
 
@@ -2824,14 +2922,28 @@ defmodule PhoenixKitEntities.Web.EntityForm do
               </button>
             </div>
 
-            <button
-              type="submit"
-              class="btn btn-primary"
-              disabled={!@changeset.valid? or @readonly?}
-              phx-disable-with={gettext("Saving…")}
-            >
-              {if @entity.uuid, do: gettext("Update Entity"), else: gettext("Create Entity")}
-            </button>
+            <div class="flex gap-2">
+              <button
+                type="submit"
+                class="btn btn-primary btn-outline"
+                disabled={!@changeset.valid? or @readonly?}
+                phx-disable-with={gettext("Saving…")}
+              >
+                {if @entity.uuid, do: gettext("Update Entity"), else: gettext("Create Entity")}
+              </button>
+              <button
+                type="submit"
+                name="return_to_list"
+                value="true"
+                class="btn btn-primary"
+                disabled={!@changeset.valid? or @readonly?}
+                phx-disable-with={gettext("Saving…")}
+              >
+                {if @entity.uuid,
+                  do: gettext("Update and Return"),
+                  else: gettext("Create and Return")}
+              </button>
+            </div>
           </div>
         </.form>
 

--- a/test/phoenix_kit_entities/entity_data_parent_test.exs
+++ b/test/phoenix_kit_entities/entity_data_parent_test.exs
@@ -1,0 +1,243 @@
+defmodule PhoenixKitEntities.EntityDataParentTest do
+  @moduledoc """
+  Parent reference (self-FK) behaviour for EntityData. Covers
+  changeset validations (self-parent, same-entity, cycle), tree
+  helpers (`list_tree/2`, `descendant_uuids/3`), and the
+  has-live-children block on `delete/2` + `bulk_delete/2`.
+
+  Soft-delete interplay: trashed children do NOT block hard-deleting
+  their parent — the trash row stays alive only for parent-app FK
+  resolution, not entity-internal tree integrity.
+  """
+
+  use PhoenixKitEntities.DataCase, async: false
+
+  alias Ecto.UUID
+  alias PhoenixKitEntities, as: Entities
+  alias PhoenixKitEntities.EntityData
+
+  setup do
+    actor_uuid = UUID.generate()
+
+    {:ok, entity_a} =
+      Entities.create_entity(
+        %{
+          name: "parent_test_a",
+          display_name: "Parent Test A",
+          display_name_plural: "Parent Tests A",
+          fields_definition: [],
+          status: "published",
+          created_by_uuid: actor_uuid
+        },
+        actor_uuid: actor_uuid
+      )
+
+    {:ok, entity_b} =
+      Entities.create_entity(
+        %{
+          name: "parent_test_b",
+          display_name: "Parent Test B",
+          display_name_plural: "Parent Tests B",
+          fields_definition: [],
+          status: "published",
+          created_by_uuid: actor_uuid
+        },
+        actor_uuid: actor_uuid
+      )
+
+    %{actor_uuid: actor_uuid, entity_a: entity_a, entity_b: entity_b}
+  end
+
+  defp create_record(entity, title, attrs, actor_uuid) do
+    base = %{
+      entity_uuid: entity.uuid,
+      title: title,
+      status: "published",
+      created_by_uuid: actor_uuid
+    }
+
+    {:ok, r} = EntityData.create(Map.merge(base, attrs), actor_uuid: actor_uuid)
+    r
+  end
+
+  describe "changeset parent validations" do
+    test "rejects a record as its own parent", %{entity_a: entity_a, actor_uuid: actor_uuid} do
+      root = create_record(entity_a, "Root", %{}, actor_uuid)
+
+      changeset = EntityData.change(root, %{parent_uuid: root.uuid})
+
+      refute changeset.valid?
+      assert {_msg, _opts} = changeset.errors[:parent_uuid]
+    end
+
+    test "rejects a parent from a different entity", %{
+      entity_a: entity_a,
+      entity_b: entity_b,
+      actor_uuid: actor_uuid
+    } do
+      a_root = create_record(entity_a, "A root", %{}, actor_uuid)
+      b_root = create_record(entity_b, "B root", %{}, actor_uuid)
+
+      {:error, changeset} = EntityData.update(a_root, %{parent_uuid: b_root.uuid})
+
+      refute changeset.valid?
+      assert {msg, _} = changeset.errors[:parent_uuid]
+      assert msg =~ "same entity"
+    end
+
+    test "rejects a parent that is the record's descendant (cycle)", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      a = create_record(entity_a, "A", %{}, actor_uuid)
+      b = create_record(entity_a, "B", %{parent_uuid: a.uuid}, actor_uuid)
+      c = create_record(entity_a, "C", %{parent_uuid: b.uuid}, actor_uuid)
+
+      # Setting A.parent_uuid = C would create A → C → B → A
+      {:error, changeset} = EntityData.update(a, %{parent_uuid: c.uuid})
+
+      refute changeset.valid?
+      assert {msg, _} = changeset.errors[:parent_uuid]
+      assert msg =~ "descendant"
+    end
+
+    test "accepts a NULL parent (root)", %{entity_a: entity_a, actor_uuid: actor_uuid} do
+      root = create_record(entity_a, "Root", %{}, actor_uuid)
+      assert {:ok, _} = EntityData.update(root, %{parent_uuid: nil})
+    end
+
+    test "accepts a same-entity parent", %{entity_a: entity_a, actor_uuid: actor_uuid} do
+      parent = create_record(entity_a, "P", %{}, actor_uuid)
+      child = create_record(entity_a, "C", %{}, actor_uuid)
+      assert {:ok, updated} = EntityData.update(child, %{parent_uuid: parent.uuid})
+      assert updated.parent_uuid == parent.uuid
+    end
+  end
+
+  describe "list_tree/2" do
+    test "returns rows depth-ordered with parents preceding children", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      root1 = create_record(entity_a, "Root1", %{}, actor_uuid)
+      root2 = create_record(entity_a, "Root2", %{}, actor_uuid)
+      child = create_record(entity_a, "Child of Root1", %{parent_uuid: root1.uuid}, actor_uuid)
+
+      grandchild =
+        create_record(entity_a, "Grandchild", %{parent_uuid: child.uuid}, actor_uuid)
+
+      tree = EntityData.list_tree(entity_a.uuid)
+      uuids = Enum.map(tree, & &1.record.uuid)
+      depths = Map.new(tree, fn %{record: r, depth: d} -> {r.uuid, d} end)
+
+      # Both roots are at depth 0
+      assert depths[root1.uuid] == 0
+      assert depths[root2.uuid] == 0
+      # Child at depth 1, grandchild at depth 2
+      assert depths[child.uuid] == 1
+      assert depths[grandchild.uuid] == 2
+
+      # Root1 precedes its children which precede the grandchild
+      assert_index_order(uuids, [root1.uuid, child.uuid, grandchild.uuid])
+    end
+  end
+
+  describe "descendant_uuids/3" do
+    test "returns all descendants (children + grandchildren)", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      root = create_record(entity_a, "Root", %{}, actor_uuid)
+      child = create_record(entity_a, "Child", %{parent_uuid: root.uuid}, actor_uuid)
+      grandchild = create_record(entity_a, "Grand", %{parent_uuid: child.uuid}, actor_uuid)
+      _sibling_root = create_record(entity_a, "Sib", %{}, actor_uuid)
+
+      result = EntityData.descendant_uuids(root.uuid, entity_a.uuid)
+
+      assert MapSet.new(result) == MapSet.new([child.uuid, grandchild.uuid])
+    end
+
+    test "returns [] for a leaf row", %{entity_a: entity_a, actor_uuid: actor_uuid} do
+      leaf = create_record(entity_a, "Leaf", %{}, actor_uuid)
+      assert EntityData.descendant_uuids(leaf.uuid, entity_a.uuid) == []
+    end
+
+    test "returns [] for nil uuid", %{entity_a: entity_a} do
+      assert EntityData.descendant_uuids(nil, entity_a.uuid) == []
+    end
+  end
+
+  describe "hard-delete with children" do
+    test "blocks delete when a live child exists", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      parent = create_record(entity_a, "P", %{}, actor_uuid)
+      _child = create_record(entity_a, "C", %{parent_uuid: parent.uuid}, actor_uuid)
+
+      assert {:error, :has_children} = EntityData.delete(parent, actor_uuid: actor_uuid)
+    end
+
+    test "allows delete when only trashed children exist", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      parent = create_record(entity_a, "P", %{}, actor_uuid)
+      child = create_record(entity_a, "C", %{parent_uuid: parent.uuid}, actor_uuid)
+      {:ok, _} = EntityData.trash(child, actor_uuid: actor_uuid)
+
+      assert {:ok, _} = EntityData.delete(parent, actor_uuid: actor_uuid)
+    end
+
+    test "allows delete when the record has no children", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      leaf = create_record(entity_a, "Leaf", %{}, actor_uuid)
+      assert {:ok, _} = EntityData.delete(leaf, actor_uuid: actor_uuid)
+    end
+  end
+
+  describe "bulk_delete with children" do
+    test "blocks when an external live child references the set", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      parent = create_record(entity_a, "P", %{}, actor_uuid)
+      _external_child = create_record(entity_a, "C", %{parent_uuid: parent.uuid}, actor_uuid)
+
+      assert {:error, :has_children} =
+               EntityData.bulk_delete([parent.uuid], actor_uuid: actor_uuid)
+    end
+
+    test "allows bulk_delete when all children are in the input set", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      parent = create_record(entity_a, "P", %{}, actor_uuid)
+      child = create_record(entity_a, "C", %{parent_uuid: parent.uuid}, actor_uuid)
+
+      assert {2, nil} =
+               EntityData.bulk_delete([parent.uuid, child.uuid], actor_uuid: actor_uuid)
+    end
+
+    test "allows bulk_delete when external children are trashed", %{
+      entity_a: entity_a,
+      actor_uuid: actor_uuid
+    } do
+      parent = create_record(entity_a, "P", %{}, actor_uuid)
+      child = create_record(entity_a, "C", %{parent_uuid: parent.uuid}, actor_uuid)
+      {:ok, _} = EntityData.trash(child, actor_uuid: actor_uuid)
+
+      assert {1, nil} = EntityData.bulk_delete([parent.uuid], actor_uuid: actor_uuid)
+    end
+  end
+
+  # Asserts that the elements of `expected` appear in `list` in the
+  # given relative order (other elements may be interleaved).
+  defp assert_index_order(list, expected) do
+    indexed = list |> Enum.with_index() |> Map.new()
+    positions = Enum.map(expected, &Map.fetch!(indexed, &1))
+    assert positions == Enum.sort(positions)
+  end
+end

--- a/test/phoenix_kit_entities/entity_data_trash_test.exs
+++ b/test/phoenix_kit_entities/entity_data_trash_test.exs
@@ -565,17 +565,40 @@ defmodule PhoenixKitEntities.EntityDataTrashTest do
       assert EntityData.count_external_references(record) == 10
     end
 
-    test "ignores callbacks that raise", ctx do
+    test "swallows DB-availability raises and logs a warning", ctx do
       [record | _] = ctx.records
 
       Application.put_env(:phoenix_kit_entities, :reverse_references, [
-        {"trash_test", fn _uuid -> raise "boom" end},
+        {"trash_test",
+         fn _uuid ->
+           raise DBConnection.ConnectionError, message: "no connection"
+         end},
         {"trash_test", fn _uuid -> 5 end}
       ])
 
       on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
 
-      assert EntityData.count_external_references(record) == 5
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert EntityData.count_external_references(record) == 5
+        end)
+
+      assert log =~ "reverse_references callback failed"
+    end
+
+    test "lets non-DB callback bugs propagate (a broken callback is a real bug)",
+         ctx do
+      [record | _] = ctx.records
+
+      Application.put_env(:phoenix_kit_entities, :reverse_references, [
+        {"trash_test", fn _uuid -> raise "boom" end}
+      ])
+
+      on_exit(fn -> Application.delete_env(:phoenix_kit_entities, :reverse_references) end)
+
+      assert_raise RuntimeError, "boom", fn ->
+        EntityData.count_external_references(record)
+      end
     end
 
     test "ignores callbacks returning negative integers", ctx do

--- a/test/phoenix_kit_entities/errors_test.exs
+++ b/test/phoenix_kit_entities/errors_test.exs
@@ -41,6 +41,11 @@ defmodule PhoenixKitEntities.ErrorsTest do
       assert msg =~ "Cannot permanently delete"
       assert msg =~ "referenced by other tables"
     end
+
+    test ":has_children" do
+      assert Errors.message(:has_children) ==
+               "Cannot permanently delete: this record has child records. Reassign or delete its children first."
+    end
   end
 
   describe "message/1 tagged tuples" do

--- a/test/phoenix_kit_entities/web/data_form_live_test.exs
+++ b/test/phoenix_kit_entities/web/data_form_live_test.exs
@@ -275,6 +275,142 @@ defmodule PhoenixKitEntities.Web.DataFormLiveTest do
     end
   end
 
+  describe "parent picker" do
+    setup ctx do
+      # Build a 3-deep chain in ctx.entity: A → B → C
+      {:ok, a} =
+        EntityData.create(
+          %{
+            entity_uuid: ctx.entity.uuid,
+            title: "A",
+            status: "published",
+            created_by_uuid: ctx.actor_uuid
+          },
+          actor_uuid: ctx.actor_uuid
+        )
+
+      {:ok, b} =
+        EntityData.create(
+          %{
+            entity_uuid: ctx.entity.uuid,
+            title: "B",
+            status: "published",
+            parent_uuid: a.uuid,
+            created_by_uuid: ctx.actor_uuid
+          },
+          actor_uuid: ctx.actor_uuid
+        )
+
+      {:ok, c} =
+        EntityData.create(
+          %{
+            entity_uuid: ctx.entity.uuid,
+            title: "C",
+            status: "published",
+            parent_uuid: b.uuid,
+            created_by_uuid: ctx.actor_uuid
+          },
+          actor_uuid: ctx.actor_uuid
+        )
+
+      {:ok, other_entity} =
+        Entities.create_entity(
+          %{
+            name: "df_other",
+            display_name: "Other",
+            display_name_plural: "Others",
+            fields_definition: [],
+            status: "published",
+            created_by_uuid: ctx.actor_uuid
+          },
+          actor_uuid: ctx.actor_uuid
+        )
+
+      {:ok, other_record} =
+        EntityData.create(
+          %{
+            entity_uuid: other_entity.uuid,
+            title: "From other entity",
+            status: "published",
+            created_by_uuid: ctx.actor_uuid
+          },
+          actor_uuid: ctx.actor_uuid
+        )
+
+      {:ok, a: a, b: b, c: c, other_entity: other_entity, other_record: other_record}
+    end
+
+    test "happy path — saving with a valid same-entity parent persists parent_uuid",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, edit_url(ctx.entity, ctx.record))
+
+      view
+      |> form("form", phoenix_kit_entity_data: %{parent_uuid: ctx.a.uuid})
+      |> render_submit()
+
+      assert EntityData.get(ctx.record.uuid).parent_uuid == ctx.a.uuid
+    end
+
+    # For the three rejection tests below, `Phoenix.LiveViewTest.form/3`
+    # validates submitted select values against the picker's rendered
+    # options — which is exactly what the LV does for happy users.
+    # These tests simulate a bypass attempt (custom client / crafted
+    # payload) by firing the "save" event directly so the changeset
+    # layer's validations are what's exercised, not the form helper.
+    test "rejects self-parent — record cannot be its own parent",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, edit_url(ctx.entity, ctx.record))
+
+      render_hook(view, "save", %{
+        "phoenix_kit_entity_data" => %{"parent_uuid" => ctx.record.uuid}
+      })
+
+      assert is_nil(EntityData.get(ctx.record.uuid).parent_uuid)
+    end
+
+    test "rejects a parent from a different entity",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, edit_url(ctx.entity, ctx.record))
+
+      render_hook(view, "save", %{
+        "phoenix_kit_entity_data" => %{"parent_uuid" => ctx.other_record.uuid}
+      })
+
+      assert is_nil(EntityData.get(ctx.record.uuid).parent_uuid)
+    end
+
+    test "rejects a parent that is the record's descendant (cycle)",
+         %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, edit_url(ctx.entity, ctx.a))
+
+      # A → C would form A→C→B→A.
+      render_hook(view, "save", %{
+        "phoenix_kit_entity_data" => %{"parent_uuid" => ctx.c.uuid}
+      })
+
+      assert is_nil(EntityData.get(ctx.a.uuid).parent_uuid)
+    end
+
+    test "clearing parent_uuid (selecting None) persists nil",
+         %{conn: conn} = ctx do
+      {:ok, _} = EntityData.update(ctx.record, %{parent_uuid: ctx.a.uuid})
+      assert EntityData.get(ctx.record.uuid).parent_uuid == ctx.a.uuid
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, edit_url(ctx.entity, ctx.record))
+
+      view
+      |> form("form", phoenix_kit_entity_data: %{parent_uuid: ""})
+      |> render_submit()
+
+      assert is_nil(EntityData.get(ctx.record.uuid).parent_uuid)
+    end
+  end
+
   # ── helpers ──────────────────────────────────────────────────
 
   defp edit_url(entity, record),

--- a/test/phoenix_kit_entities/web/data_navigator_live_test.exs
+++ b/test/phoenix_kit_entities/web/data_navigator_live_test.exs
@@ -489,6 +489,41 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
       )
     end
 
+    test "permanent_delete flashes :has_children when the trashed row has a live child",
+         %{conn: conn} = ctx do
+      [parent | _] = ctx.records
+
+      # Live child that points at the parent we're about to trash.
+      {:ok, _child} =
+        EntityData.create(
+          %{
+            entity_uuid: ctx.entity.uuid,
+            title: "Child of #{parent.title}",
+            status: "published",
+            parent_uuid: parent.uuid,
+            created_by_uuid: ctx.actor_uuid
+          },
+          actor_uuid: ctx.actor_uuid
+        )
+
+      {:ok, _} = EntityData.trash(parent, actor_uuid: ctx.actor_uuid)
+
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "trashed"))
+
+      render_hook(view, "permanent_delete", %{"uuid" => parent.uuid})
+
+      assert render(view) =~ "has child records"
+      assert %EntityData{status: "trashed"} = EntityData.get(parent.uuid)
+
+      # Error-branch audit pins the user-initiated action even though
+      # the DB rolled back.
+      assert_activity_logged("entity_data.deleted",
+        actor_uuid: ctx.actor_uuid,
+        metadata_has: %{"db_pending" => true}
+      )
+    end
+
     test "bulk_action 'permanent_delete' hard-deletes selected trashed records",
          %{conn: conn} = ctx do
       [r1, r2, _r3] = ctx.records

--- a/test/phoenix_kit_entities/web/data_navigator_live_test.exs
+++ b/test/phoenix_kit_entities/web/data_navigator_live_test.exs
@@ -65,9 +65,12 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
       conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
       {:ok, view, _html} = live(conn, navigator_url(ctx.entity))
 
+      # Table view renders actions inside `<.table_row_menu>`; scope to
+      # the menu's unique id so the card view's inline button doesn't
+      # match too.
       view
       |> element(
-        "button[phx-click='archive_data'][phx-value-uuid='#{record.uuid}'][data-tip='Archive']"
+        "#data-menu-#{record.uuid} button[phx-click='archive_data']"
       )
       |> render_click()
 
@@ -92,7 +95,7 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
 
       view
       |> element(
-        "button[phx-click='restore_data'][phx-value-uuid='#{record.uuid}'][data-tip='Restore']"
+        "#data-menu-#{record.uuid} button[phx-click='restore_data']"
       )
       |> render_click()
 
@@ -110,9 +113,20 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
       conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
       {:ok, _view, html} = live(conn, navigator_url(ctx.entity))
 
-      # delta-pin C5: archive button has phx-disable-with attr.
-      assert html =~
-               ~r/phx-click="archive_data"[^>]*phx-value-uuid="#{record.uuid}"[^>]*phx-disable-with=/
+      # delta-pin C5: archive button has phx-disable-with attr. The
+      # button now lives inside `<.table_row_menu>`; isolate the menu's
+      # subtree for this record (scoped by its id) and assert both
+      # signals appear inside it. `:global` attrs aren't source-ordered
+      # so we don't pin them to a single tag.
+      menu_id = "data-menu-#{record.uuid}"
+
+      menu_html =
+        Regex.run(~r/<div id="#{menu_id}".*?<\/div>/s, html)
+        |> List.first()
+
+      assert is_binary(menu_html), "expected dropdown markup for #{menu_id}"
+      assert menu_html =~ ~s(phx-click="archive_data")
+      assert menu_html =~ "phx-disable-with="
     end
   end
 

--- a/test/phoenix_kit_entities/web/entities_live_test.exs
+++ b/test/phoenix_kit_entities/web/entities_live_test.exs
@@ -52,11 +52,12 @@ defmodule PhoenixKitEntities.Web.EntitiesLiveTest do
       conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
       {:ok, view, _html} = live(conn, "/en/admin/entities")
 
-      # Two buttons match (table view + card view); target the table-view
-      # one via the `data-tip` attribute.
+      # Table view renders the action inside `<.table_row_menu>`; scope
+      # the selector to that menu's unique id (card view has its own
+      # inline button on the same uuid).
       view
       |> element(
-        "button[phx-click='archive_entity'][phx-value-uuid='#{ctx.published.uuid}'][data-tip='Archive']"
+        "#entity-menu-#{ctx.published.uuid} button[phx-click='archive_entity']"
       )
       |> render_click()
 
@@ -76,9 +77,18 @@ defmodule PhoenixKitEntities.Web.EntitiesLiveTest do
       {:ok, _view, html} = live(conn, "/en/admin/entities")
 
       # delta-pin: phx-disable-with attr present on every async/destructive
-      # phx-click button (C5). Regex-match because the attr is one of many.
-      assert html =~
-               ~r/phx-click="archive_entity"[^>]*phx-value-uuid="#{ctx.published.uuid}"[^>]*phx-disable-with=/
+      # phx-click button (C5). Action lives inside `<.table_row_menu>`;
+      # `:global` attrs aren't source-ordered so we scope to the menu's
+      # subtree by id and assert both signals appear inside it.
+      menu_id = "entity-menu-#{ctx.published.uuid}"
+
+      menu_html =
+        Regex.run(~r/<div id="#{menu_id}".*?<\/div>/s, html)
+        |> List.first()
+
+      assert is_binary(menu_html), "expected dropdown markup for #{menu_id}"
+      assert menu_html =~ ~s(phx-click="archive_entity")
+      assert menu_html =~ "phx-disable-with="
     end
   end
 
@@ -90,7 +100,7 @@ defmodule PhoenixKitEntities.Web.EntitiesLiveTest do
 
       view
       |> element(
-        "button[phx-click='restore_entity'][phx-value-uuid='#{ctx.archived.uuid}'][data-tip='Restore']"
+        "#entity-menu-#{ctx.archived.uuid} button[phx-click='restore_entity']"
       )
       |> render_click()
 

--- a/test/phoenix_kit_entities/web/entity_form_live_test.exs
+++ b/test/phoenix_kit_entities/web/entity_form_live_test.exs
@@ -72,6 +72,48 @@ defmodule PhoenixKitEntities.Web.EntityFormLiveTest do
     end
   end
 
+  describe "save_and_return" do
+    test "Update and Return navigates back to /admin/entities", %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, "/en/admin/entities/#{ctx.entity.uuid}/edit")
+
+      # The form has TWO submit buttons in each action row. The plain
+      # "Update Entity" button submits the form without `return_to_list`;
+      # the "Update and Return" button carries `name="return_to_list"
+      # value="true"`. Phoenix's `render_submit/2` second arg lets us
+      # inject the second-button params on top of the form fields.
+      view
+      |> form("form[phx-change='validate']", %{
+        "entities" => %{"display_name" => "Updated Display Name"}
+      })
+      |> render_submit(%{"return_to_list" => "true"})
+
+      # The LV pushes navigate to /admin/entities under the configured
+      # locale (or the referrer if one was captured at mount — none
+      # here so it falls back to the list path).
+      assert_redirected(view, "/phoenix_kit/en-US/admin/entities")
+    end
+
+    test "plain Update keeps you on the edit page", %{conn: conn} = ctx do
+      conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))
+      {:ok, view, _html} = live(conn, "/en/admin/entities/#{ctx.entity.uuid}/edit")
+
+      # Submit without `return_to_list` — same form, plain button.
+      view
+      |> form("form[phx-change='validate']", %{
+        "entities" => %{"display_name" => "Stay Put"}
+      })
+      |> render_submit()
+
+      # No redirect — the view stays on the edit page (handle_save_success
+      # falls through to the "stay on edit" branch). Render-after-submit
+      # would crash if a push_navigate had fired.
+      assert render(view) =~ "Edit Entity"
+      # And the save actually persisted.
+      assert Entities.get_entity!(ctx.entity.uuid).display_name == "Stay Put"
+    end
+  end
+
   describe "switch_language event" do
     test "ignores unknown language and stays on the form", %{conn: conn} = ctx do
       conn = put_test_scope(conn, fake_scope(user_uuid: ctx.actor_uuid))


### PR DESCRIPTION
## Summary

Six commits landing on top of post-PR-#14 `main`. Three feature
commits + a feature follow-up batch + a re-validation sweep — each
commit is bisect-friendly and reviewable in isolation.

## Companion PR

`BeamLabEU/phoenix_kit#538` — ships **V116** (`parent_uuid` self-FK on
`phoenix_kit_entity_data`) and the new `:sortable_handle` attr on
`<.draggable_list>`. This PR consumes both. CI here is red against
hex until that lands; `mix deps.update phoenix_kit` then greens it.

## Commits

### Feature commits

- `627981d` — **Add `parent_uuid` support to EntityData.** Schema +
  changeset (`belongs_to(:parent)` + `has_many(:children)`,
  `validate_not_self_parent`, context-layer same-entity check,
  bounded ancestor walk to prevent cycles). Tree helpers
  (`list_tree/2`, `descendant_uuids/3`). Hard-delete blocks on live
  children, nullifies trashed children inside a transaction (matches
  V103's context-layer cascade pattern). `Errors.message(:has_children)`
  + new error atom. DataForm parent picker (Record Settings card,
  rendered in both multilang and non-multilang branches). 15 new
  pinning tests.

- `90edc9e` — **Add `Create/Update and Return` buttons** to the
  entity form. Smart return target: WS-connect captures
  `_live_referer` via `get_connect_params/1`, validates path lives
  under `/admin`, drops self-referrer if reload of the edit page,
  falls back to `/admin/entities`. `Update and Return` is the primary
  (solid) button; plain `Update Entity` is the outline secondary
  — return is the default expectation.

- `0e2c7d7` — **Tables overhaul.** Action columns switched to
  `<.table_row_menu>` kebab dropdowns (canonical workspace pattern
  per catalogue / staff / settings/integrations). Items render in
  the default neutral color — destructive intent comes from labels
  + confirm dialogs. WordPress-style tree rendering in DataNavigator
  (`— ` * depth prefix on title). Handle-only DnD via
  `:sortable_handle=\".pk-drag-handle\"` — table handle uses
  `text-base-content/30 hover:/70`, card handle uses
  `text-base-content/0 group-hover/card:/50` (invisible until card
  hover). Reorder confirmation flash: `reorder_*` handlers read
  `moved_id` and push `sortable:flash` so the dropped row pulses
  green / red. Actions column collapsed to content width
  (`w-px whitespace-nowrap text-right`).

### PR follow-ups

- `da7be2a` — **PR #13 (soft-delete) review follow-up: F1-F9.**
  Focused `status_only_changeset/3` for trash/restore so a record
  with stale data still trashable (F1). Trash stashes prior status
  in `metadata[\"trashed_from_status\"]`; restore reads it back
  (F2 — defaults to `\"draft\"` when missing). Narrowed
  `do_count_external_references/2` rescue to DB-availability shapes
  with `Logger.warning` — callback bugs propagate (F3). Dead
  `\"trashed\" -> \"trashed\"` clause in `toggle_status` replaced
  with a catch-all + comment (F4). Docstring fix removing nonexistent
  \"admin trash bin\" example (F5). Comments on FK-error non-clear
  of `selected_uuids` (F6). Trash flash drops the unenforced
  \"90 days\" copy (F7). AGENTS.md note on multi-tenant
  `:reverse_references` global semantic (F8). `bulk_delete` rescue
  scope tightened — extracted `run_bulk_delete_txn/1` so the rescue
  can't catch a Postgrex error from `ActivityLog.log` (F9).

- `201bb67` — **PR #14 (migration cleanup) FOLLOW_UP.md stub.**
  Both nits (broken doc ref, stale lockfile) were resolved in the
  review pass itself; this is the canonical Phase-1 record.

### Phase 2 re-validation

- `506f4ad` — **Phase 2 re-validation fixes (H1-H4, M1-M3, @spec
  backfill).** Closes every C12 finding from the three parallel
  agents (security + UX, i18n + activity + tests, PubSub +
  cleanliness + API).

  **H1 — Open redirect** on the public form controller's
  `redirect_back/2`. `redirect(conn, external: referer)` passed
  the `Referer` header unchecked. Replaced with same-host check
  (parse URI, require http/https + host match, emit path-only
  relative redirect, fall back to `/`).

  **H2/H3 — Race conditions on `delete/2` + `bulk_delete/2`.**
  `has_live_children?` / `has_external_live_children?` happened
  outside the transaction — a concurrent insert could slip a live
  child between the check and the delete and trip the DB-level FK,
  misclassifying as `:referenced_by_external`. Folded both checks
  inside `Repo.transaction` so the rollback returns `:has_children`
  cleanly.

  **H4 — `:has_children` Errors test.** Atom added in the PR #13
  follow-up wasn't pinned in `errors_test.exs`. Added the exact-
  translated-string test per the no-`is_binary` smell rule.

  **M1 — Save-and-return LV test** in `entity_form_live_test.exs`.

  **M2 — `permanent_delete` with `:has_children` LV test** in
  `data_navigator_live_test.exs`. Also added the LV-side branch
  for `:has_children` on both single + bulk paths (flash via
  `Errors.message`).

  **M3 — Parent picker LV tests** in `data_form_live_test.exs`.
  Happy path + self-parent + cross-entity + cycle (3-deep) +
  clear-parent. Rejection tests bypass the `form/3` option
  allowlist via `render_hook` to exercise the changeset layer
  validations.

  **`@spec` backfill** on ~40 public functions across
  `entity_data.ex` and `phoenix_kit_entities.ex`.

## Verification

- `mix format --check-formatted` — clean
- `mix credo --strict` — no new findings
- `mix compile` — clean (one expected `sortable_handle` undefined-attr
  warning until core's draggable_list update lands)
- `mix test` — **800 / 800 pass** (was 790 before this PR's work;
  +10 from new pinning tests).
- 3× consecutive stable runs locally.

## Test plan

- [x] Schema + changeset coverage (15 new parent_uuid tests)
- [x] LV smoke tests for every threaded opt (M1/M2/M3)
- [x] `phx-disable-with` on every destructive button (regression-pinned)
- [x] No regressions in existing 790 tests
- [x] Browser smoke: tree-indent + handle DnD + dropdowns + flash
      pulse verified locally via phoenix_kit_parent

## Coverage residual

77.29% — at the upper end of the deeply-coupled-subsystem ceiling
(63–78%) per the workspace `quality_sweep.md` playbook. Remaining
gaps live in defensive `rescue _e -> :ok` / `catch :exit, _ -> :ok`
paths (`ActivityLog`, `PresenceHelpers`) and in collaborative-
editing / Presence flows in `Web.DataForm` + `Web.EntityForm`.
Stop signal reached — pushing higher needs ≥50 tests per pp.