### PR TITLE
Adopt phoenix_kit core: empty_state, Utils.Format, site-wide `default_language_no_prefix`

### DIFF
--- a/lib/phoenix_kit_entities/entity_data.ex
+++ b/lib/phoenix_kit_entities/entity_data.ex
@@ -1919,9 +1919,7 @@ defmodule PhoenixKitEntities.EntityData do
         # callback that reports "Used by 0 rows" is the surprising
         # default this guard was supposed to prevent.
         e in [DBConnection.ConnectionError, Postgrex.Error] ->
-          Logger.warning(
-            "[Entities] reverse_references callback failed: #{Exception.message(e)}"
-          )
+          Logger.warning("[Entities] reverse_references callback failed: #{Exception.message(e)}")
 
           acc
       end

--- a/lib/phoenix_kit_entities/form_builder.ex
+++ b/lib/phoenix_kit_entities/form_builder.ex
@@ -39,6 +39,7 @@ defmodule PhoenixKitEntities.FormBuilder do
   import PhoenixKitWeb.Components.Core.FormFieldLabel, only: [label: 1]
   use Gettext, backend: PhoenixKitWeb.Gettext
 
+  alias PhoenixKit.Utils.Format
   alias PhoenixKit.Utils.Multilang
 
   @doc """
@@ -771,16 +772,7 @@ defmodule PhoenixKitEntities.FormBuilder do
     """
   end
 
-  # Helper function to format file sizes
-  defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
-
-  defp format_bytes(bytes) when bytes < 1_048_576 do
-    "#{Float.round(bytes / 1024, 1)} KB"
-  end
-
-  defp format_bytes(bytes) do
-    "#{Float.round(bytes / 1_048_576, 1)} MB"
-  end
+  defp format_bytes(bytes), do: Format.bytes(bytes)
 
   @doc """
   Validates entity data against field definitions.

--- a/lib/phoenix_kit_entities/url_resolver.ex
+++ b/lib/phoenix_kit_entities/url_resolver.ex
@@ -300,18 +300,25 @@ defmodule PhoenixKitEntities.UrlResolver do
   end
 
   @doc """
-  Adds a language prefix to a path (sitemap policy: prefix every language in multilang mode).
+  Adds a language prefix to a path for the sitemap.
 
-  Used by `PhoenixKitEntities.SitemapSource` for hreflang-aware sitemap entries.
-  Consumers building public links should prefer `add_public_locale_prefix/2`, which
-  omits the prefix for the primary language (matching `PhoenixKit.Utils.Routes` conventions).
+  Used by `PhoenixKitEntities.SitemapSource` for hreflang-aware sitemap
+  entries. The primary language follows the site-wide
+  `Languages.default_language_no_prefix?/0` setting (when ON, skip the
+  prefix; when OFF, include it). Every other language always gets the
+  prefix in multilang mode.
+
+  Pass `is_default: true` so this helper can apply the setting. Consumers
+  building public links should prefer `add_public_locale_prefix/2`, which
+  takes the same setting into account via its primary-language branch.
   """
   @spec build_path_with_language(String.t(), String.t() | nil, boolean()) :: String.t()
-  def build_path_with_language(path, language, _is_default \\ true) do
-    if language && !single_language_mode?() do
-      "/#{Languages.DialectMapper.extract_base(language)}#{path}"
-    else
-      path
+  def build_path_with_language(path, language, is_default \\ true) do
+    cond do
+      is_nil(language) -> path
+      single_language_mode?() -> path
+      is_default and prefixless_primary?() -> path
+      true -> "/#{Languages.DialectMapper.extract_base(language)}#{path}"
     end
   end
 
@@ -321,11 +328,14 @@ defmodule PhoenixKitEntities.UrlResolver do
   Policy:
   - Single-language mode → no prefix
   - Locale is `nil`, empty, or malformed → no prefix
-  - Locale matches the primary language → no prefix
+  - Locale matches the primary language → follows the site-wide
+    `Languages.default_language_no_prefix?/0` setting (when ON, skip
+    the prefix; when OFF, include it — `/<base>`)
   - Otherwise → `/<base>` prefix (where `<base>` is a validated base code)
 
   This matches the convention used by `PhoenixKit.Utils.Routes.path/2`
-  (default locale served from unprefixed URLs).
+  and `PhoenixKit.Utils.Routes.admin_path/2`, which both honor the same
+  setting.
 
   The base code is validated against `^[a-z]{2,3}$` before interpolation, so
   caller-supplied locales (for example from request params) cannot inject
@@ -340,7 +350,7 @@ defmodule PhoenixKitEntities.UrlResolver do
       single_language_mode?() ->
         path
 
-      primary_language_base?(locale) ->
+      primary_language_base?(locale) and prefixless_primary?() ->
         path
 
       true ->
@@ -349,6 +359,16 @@ defmodule PhoenixKitEntities.UrlResolver do
           base -> "/#{base}#{path}"
         end
     end
+  end
+
+  # Reads the site-wide setting `Languages.default_language_no_prefix?/0`
+  # (managed on `/admin/settings/languages`). Wrapped to survive boot /
+  # mix-task contexts where the settings table may not exist yet — same
+  # defensive shape as `single_language_mode?/0`.
+  defp prefixless_primary? do
+    Languages.default_language_no_prefix?()
+  rescue
+    _ -> false
   end
 
   # Extracts a base locale code and validates it against a strict allowlist

--- a/lib/phoenix_kit_entities/web/data_navigator.ex
+++ b/lib/phoenix_kit_entities/web/data_navigator.ex
@@ -366,8 +366,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
            put_flash(socket, :error, PhoenixKitEntities.Errors.message(:referenced_by_external))}
 
         {:error, :has_children} ->
-          {:noreply,
-           put_flash(socket, :error, PhoenixKitEntities.Errors.message(:has_children))}
+          {:noreply, put_flash(socket, :error, PhoenixKitEntities.Errors.message(:has_children))}
 
         {:error, _} ->
           {:noreply, put_flash(socket, :error, gettext("Failed to delete record"))}
@@ -618,8 +617,7 @@ defmodule PhoenixKitEntities.Web.DataNavigator do
          put_flash(socket, :error, PhoenixKitEntities.Errors.message(:referenced_by_external))}
 
       {:error, :has_children} ->
-        {:noreply,
-         put_flash(socket, :error, PhoenixKitEntities.Errors.message(:has_children))}
+        {:noreply, put_flash(socket, :error, PhoenixKitEntities.Errors.message(:has_children))}
     end
   end
 

--- a/lib/phoenix_kit_entities/web/entities.ex
+++ b/lib/phoenix_kit_entities/web/entities.ex
@@ -237,26 +237,23 @@ defmodule PhoenixKitEntities.Web.Entities do
 
         <%!-- Entities Grid --%>
         <%= if Enum.empty?(@entities) do %>
-          <%!-- Empty State --%>
-          <div class="card bg-base-100 shadow-xl border-2 border-dashed border-base-300">
-            <div class="card-body text-center py-12">
-              <div class="text-6xl mb-4 opacity-50"><.icon name="hero-cube" class="w-6 h-6" /></div>
-              <h3 class="text-2xl font-semibold text-base-content/60 mb-4">
-                {gettext("No Entities Yet")}
-              </h3>
-              <p class="text-base-content/50 mb-6 max-w-md mx-auto">
-                {gettext(
-                  "Get started by creating your first custom content type. Think brands, products, team members, or any structured content you need."
-                )}
-              </p>
-              <.link
-                navigate={PhoenixKit.Utils.Routes.path("/admin/entities/new")}
-                class="btn btn-primary btn-lg"
-              >
-                <.icon name="hero-plus" class="w-5 h-5 mr-2" /> {gettext("Create Your First Entity")}
-              </.link>
-            </div>
-          </div>
+          <.empty_state
+            variant="featured"
+            icon="hero-cube"
+            title={gettext("No Entities Yet")}
+            description={
+              gettext(
+                "Get started by creating your first custom content type. Think brands, products, team members, or any structured content you need."
+              )
+            }
+          >
+            <.link
+              navigate={PhoenixKit.Utils.Routes.path("/admin/entities/new")}
+              class="btn btn-primary btn-lg"
+            >
+              <.icon name="hero-plus" class="w-5 h-5 mr-2" /> {gettext("Create Your First Entity")}
+            </.link>
+          </.empty_state>
         <% else %>
           <%!-- Table View: hidden on small screens, shown on md+ when table mode selected --%>
           <%= if @view_mode == "table" do %>

--- a/lib/phoenix_kit_entities/web/entity_form.ex
+++ b/lib/phoenix_kit_entities/web/entity_form.ex
@@ -103,8 +103,9 @@ defmodule PhoenixKitEntities.Web.EntityForm do
       path ->
         current_path = URI.parse(uri).path
 
-        if current_path && String.trim_trailing(current_path, "/") ==
-             String.trim_trailing(path, "/") do
+        if current_path &&
+             String.trim_trailing(current_path, "/") ==
+               String.trim_trailing(path, "/") do
           assign(socket, :return_to_path, nil)
         else
           socket

--- a/test/phoenix_kit_entities/entity_data_url_multilang_test.exs
+++ b/test/phoenix_kit_entities/entity_data_url_multilang_test.exs
@@ -1,0 +1,137 @@
+defmodule PhoenixKitEntities.EntityDataUrlMultilangTest do
+  @moduledoc """
+  Integration coverage for `EntityData.public_path/3` and
+  `public_alternates/3` crossing the `UrlResolver.add_public_locale_prefix/2`
+  helper.
+
+  The helper is unit-tested in isolation in `url_resolver_multilang_test.exs`,
+  but the path *through* `EntityData.public_path/3` is what host apps
+  actually call. This file pins the end-to-end shape under both states
+  of the site-wide `default_language_no_prefix` setting so the helper
+  + caller contract stays observed if either side refactors.
+  """
+
+  use PhoenixKitEntities.DataCase, async: false
+
+  alias PhoenixKit.Modules.Languages
+  alias PhoenixKit.Settings
+  alias PhoenixKitEntities.EntityData
+
+  setup do
+    config = %{
+      "languages" => [
+        %{
+          "code" => "en",
+          "name" => "English",
+          "is_default" => true,
+          "is_enabled" => true,
+          "position" => 1
+        },
+        %{
+          "code" => "es",
+          "name" => "Spanish",
+          "is_default" => false,
+          "is_enabled" => true,
+          "position" => 2
+        }
+      ]
+    }
+
+    Settings.update_setting("languages_enabled", "true")
+    Settings.update_json_setting("languages_config", config)
+
+    on_exit(fn ->
+      Settings.update_setting("languages_enabled", "false")
+      Languages.set_default_language_no_prefix(false)
+    end)
+
+    entity = %{name: "product", settings: %{"sitemap_url_pattern" => "/products/:slug"}}
+    record = %{uuid: "uuid-1", slug: "my-item"}
+    cache = %{entity_patterns: %{}, entity_index_paths: %{}}
+
+    {:ok, entity: entity, record: record, cache: cache}
+  end
+
+  describe "public_path/3 — multilang, setting OFF (default)" do
+    test "primary locale gets the prefix (canonical prefixed shape)", ctx do
+      assert EntityData.public_path(ctx.entity, ctx.record,
+               routes_cache: ctx.cache,
+               locale: "en"
+             ) == "/en/products/my-item"
+    end
+
+    test "non-primary locale gets its own prefix", ctx do
+      assert EntityData.public_path(ctx.entity, ctx.record,
+               routes_cache: ctx.cache,
+               locale: "es"
+             ) == "/es/products/my-item"
+    end
+
+    test "nil locale returns bare path", ctx do
+      assert EntityData.public_path(ctx.entity, ctx.record, routes_cache: ctx.cache) ==
+               "/products/my-item"
+    end
+  end
+
+  describe "public_path/3 — multilang, setting ON" do
+    setup do
+      Languages.set_default_language_no_prefix(true)
+      :ok
+    end
+
+    test "primary locale is stripped (canonical prefixless shape)", ctx do
+      assert EntityData.public_path(ctx.entity, ctx.record,
+               routes_cache: ctx.cache,
+               locale: "en"
+             ) == "/products/my-item"
+    end
+
+    test "non-primary locale still gets its prefix", ctx do
+      assert EntityData.public_path(ctx.entity, ctx.record,
+               routes_cache: ctx.cache,
+               locale: "es"
+             ) == "/es/products/my-item"
+    end
+  end
+
+  describe "public_alternates/3 — multilang canonical + hreflang URLs" do
+    test "with setting OFF, canonical is prefixed for primary", ctx do
+      result =
+        EntityData.public_alternates(ctx.entity, ctx.record,
+          routes_cache: ctx.cache,
+          base_url: "https://shop.example.com"
+        )
+
+      # Primary language canonical includes /en/
+      assert result.canonical == "https://shop.example.com/en/products/my-item"
+
+      # Alternates include both languages + x-default
+      hrefs = Enum.map(result.alternates, & &1.href)
+      assert "https://shop.example.com/en/products/my-item" in hrefs
+      assert "https://shop.example.com/es/products/my-item" in hrefs
+
+      # x-default points to the canonical primary URL
+      assert Enum.find(result.alternates, &(&1.locale == "x-default")).href ==
+               "https://shop.example.com/en/products/my-item"
+    end
+
+    test "with setting ON, canonical is prefixless for primary", ctx do
+      Languages.set_default_language_no_prefix(true)
+
+      result =
+        EntityData.public_alternates(ctx.entity, ctx.record,
+          routes_cache: ctx.cache,
+          base_url: "https://shop.example.com"
+        )
+
+      assert result.canonical == "https://shop.example.com/products/my-item"
+
+      hrefs = Enum.map(result.alternates, & &1.href)
+      assert "https://shop.example.com/products/my-item" in hrefs
+      assert "https://shop.example.com/es/products/my-item" in hrefs
+
+      assert Enum.find(result.alternates, &(&1.locale == "x-default")).href ==
+               "https://shop.example.com/products/my-item"
+    end
+  end
+end

--- a/test/phoenix_kit_entities/url_resolver_multilang_test.exs
+++ b/test/phoenix_kit_entities/url_resolver_multilang_test.exs
@@ -77,13 +77,17 @@ defmodule PhoenixKitEntities.UrlResolverMultilangTest do
     end
   end
 
-  describe "add_public_locale_prefix/2 in multilang mode" do
-    test "primary language gets no prefix" do
-      assert UrlResolver.add_public_locale_prefix("/foo", "en") == "/foo"
+  describe "add_public_locale_prefix/2 in multilang mode (default_language_no_prefix OFF)" do
+    # OFF is the default state in this setup — `languages_enabled` is set
+    # but no one writes `default_language_no_prefix`, so the getter falls
+    # back to false. Primary languages get the prefix like every other.
+
+    test "primary language gets the prefix (setting OFF)" do
+      assert UrlResolver.add_public_locale_prefix("/foo", "en") == "/en/foo"
     end
 
-    test "primary dialect (en-US) also gets no prefix because base matches" do
-      assert UrlResolver.add_public_locale_prefix("/foo", "en-US") == "/foo"
+    test "primary dialect (en-US) gets the prefix" do
+      assert UrlResolver.add_public_locale_prefix("/foo", "en-US") == "/en/foo"
     end
 
     test "non-primary base prepends /es" do
@@ -102,12 +106,58 @@ defmodule PhoenixKitEntities.UrlResolverMultilangTest do
       # safe_base_code/1 rejects anything that doesn't match ^[a-z]{2,3}$
       assert UrlResolver.add_public_locale_prefix("/foo", "../etc/passwd") == "/foo"
       assert UrlResolver.add_public_locale_prefix("/foo", "12") == "/foo"
-      assert UrlResolver.add_public_locale_prefix("/foo", "EN") == "/foo"
+      # Uppercase "EN" extracts to "en" via DialectMapper. With the
+      # setting OFF, primary languages get the prefix like everyone else;
+      # this used to fall through to "no prefix" because the primary-
+      # language branch short-circuited. Now both branches converge:
+      # primary with setting off → prefix.
+      assert UrlResolver.add_public_locale_prefix("/foo", "EN") == "/en/foo"
     end
 
     test "nil and empty stay unchanged" do
       assert UrlResolver.add_public_locale_prefix("/foo", nil) == "/foo"
       assert UrlResolver.add_public_locale_prefix("/foo", "") == "/foo"
+    end
+  end
+
+  describe "add_public_locale_prefix/2 in multilang mode (default_language_no_prefix ON)" do
+    setup do
+      Settings.update_boolean_setting("default_language_no_prefix", true)
+      on_exit(fn -> Settings.update_boolean_setting("default_language_no_prefix", false) end)
+      :ok
+    end
+
+    test "primary language is stripped when setting is ON" do
+      assert UrlResolver.add_public_locale_prefix("/foo", "en") == "/foo"
+    end
+
+    test "primary dialect is stripped when setting is ON (base matches)" do
+      assert UrlResolver.add_public_locale_prefix("/foo", "en-US") == "/foo"
+    end
+
+    test "non-primary still gets the prefix when setting is ON" do
+      assert UrlResolver.add_public_locale_prefix("/foo", "es") == "/es/foo"
+      assert UrlResolver.add_public_locale_prefix("/foo", "fr") == "/fr/foo"
+    end
+  end
+
+  describe "build_path_with_language/3 — sitemap honors the setting" do
+    test "non-primary always emits prefix regardless of setting" do
+      assert UrlResolver.build_path_with_language("/p/widget", "es", false) ==
+               "/es/p/widget"
+    end
+
+    test "primary with setting OFF (default) emits the prefix" do
+      assert UrlResolver.build_path_with_language("/p/widget", "en", true) ==
+               "/en/p/widget"
+    end
+
+    test "primary with setting ON skips the prefix" do
+      Settings.update_boolean_setting("default_language_no_prefix", true)
+      on_exit(fn -> Settings.update_boolean_setting("default_language_no_prefix", false) end)
+
+      assert UrlResolver.build_path_with_language("/p/widget", "en", true) ==
+               "/p/widget"
     end
   end
 end

--- a/test/phoenix_kit_entities/web/data_navigator_live_test.exs
+++ b/test/phoenix_kit_entities/web/data_navigator_live_test.exs
@@ -69,9 +69,7 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
       # the menu's unique id so the card view's inline button doesn't
       # match too.
       view
-      |> element(
-        "#data-menu-#{record.uuid} button[phx-click='archive_data']"
-      )
+      |> element("#data-menu-#{record.uuid} button[phx-click='archive_data']")
       |> render_click()
 
       assert_activity_logged("entity_data.updated",
@@ -94,9 +92,7 @@ defmodule PhoenixKitEntities.Web.DataNavigatorLiveTest do
       {:ok, view, _html} = live(conn, navigator_url(ctx.entity, status: "archived"))
 
       view
-      |> element(
-        "#data-menu-#{record.uuid} button[phx-click='restore_data']"
-      )
+      |> element("#data-menu-#{record.uuid} button[phx-click='restore_data']")
       |> render_click()
 
       assert_activity_logged("entity_data.updated",

--- a/test/phoenix_kit_entities/web/entities_live_test.exs
+++ b/test/phoenix_kit_entities/web/entities_live_test.exs
@@ -56,9 +56,7 @@ defmodule PhoenixKitEntities.Web.EntitiesLiveTest do
       # the selector to that menu's unique id (card view has its own
       # inline button on the same uuid).
       view
-      |> element(
-        "#entity-menu-#{ctx.published.uuid} button[phx-click='archive_entity']"
-      )
+      |> element("#entity-menu-#{ctx.published.uuid} button[phx-click='archive_entity']")
       |> render_click()
 
       # Activity row reflects the threaded actor (delta-pin: actor_opts/1).
@@ -99,9 +97,7 @@ defmodule PhoenixKitEntities.Web.EntitiesLiveTest do
       {:ok, view, _html} = live(conn, "/en/admin/entities")
 
       view
-      |> element(
-        "#entity-menu-#{ctx.archived.uuid} button[phx-click='restore_entity']"
-      )
+      |> element("#entity-menu-#{ctx.archived.uuid} button[phx-click='restore_entity']")
       |> render_click()
 
       assert_activity_logged("entity.updated",


### PR DESCRIPTION
## Summary

Three downstream adopters for phoenix_kit core changes that landed
after the last entities PR:

1. **`a159f59` Use core `<.empty_state>` in entities list** — drops
   the local empty-state markup in favour of the
   `PhoenixKitWeb.Components.Core.EmptyState` component lifted into
   core via PR #551.

2. **`b61a310` Delegate `format_bytes` to `PhoenixKit.Utils.Format`** —
   the bytes-pretty-printing helper got consolidated into core.
   Entities' local copy is replaced with a delegate.

3. **`2c55854` Honor site-wide `default_language_no_prefix` in URL
   resolver** — pairs with phoenix_kit core PR #552 which makes
   `Languages.default_language_no_prefix?/0` the single source of
   truth for primary-language URL emission across the workspace.

The first two are mechanical adoptions. The third is the meaningful
change in this PR; the rest of the body covers it.

## Why (commit #3)

The entities `UrlResolver` shipped two helpers with asymmetric
hardcoded behavior that ignored any site-wide setting:

- `build_path_with_language/3` — sitemap path builder. Always
  emitted the prefix for the primary language in multilang mode,
  identical bug to the one core PR #552 fixed in
  `lib/modules/sitemap/sources/publishing.ex`.
- `add_public_locale_prefix/2` — public-URL helper. Always *stripped*
  the prefix for the primary language. Opposite asymmetry — meant
  sites with the new core setting OFF (the default) saw
  `/blog/post` from publishing's HTML builders but `/foo` (instead
  of `/en/foo`) from entities' public URLs.

Both flagged in core PR #552's "Follow-up surfaced" section.

## What changed (commit #3)

`lib/phoenix_kit_entities/url_resolver.ex`:

- **`build_path_with_language/3`** now gates the language segment
  on `is_default and prefixless_primary?()` — primary gets the
  prefix when the site-wide setting is OFF, gets stripped when ON.
  Non-primary always gets the prefix in multilang mode (unchanged).
  Rewrote the conditional as `cond` instead of nested `if` for
  readability. `is_default` is no longer the leading underscore-
  prefixed parameter; it's now load-bearing.
- **`add_public_locale_prefix/2`** primary-language branch now
  reads `primary_language_base?(locale) and prefixless_primary?()`
  — only strips when the setting is ON. With setting OFF (default),
  primary falls through to the `safe_base_code/1` branch and gets
  the prefix like any other language.
- **New private `prefixless_primary?/0`** wraps
  `Languages.default_language_no_prefix?/0` with the same defensive
  rescue as `single_language_mode?/0` (boot / mix-task contexts).

## Tests

- `test/phoenix_kit_entities/url_resolver_multilang_test.exs`
  reorganised:
  - The existing `"in multilang mode"` describe block is renamed
    to `"… (default_language_no_prefix OFF)"` and assertions are
    updated to reflect the new default (primary gets prefix). The
    `"malformed locale"` test now asserts the new path for the
    uppercase-EN edge case (used to fall through to "no prefix"
    via the primary short-circuit; now goes through
    `safe_base_code` and gets `/en/foo`).
  - **New** `"… (default_language_no_prefix ON)"` describe block
    pins the setting-ON branch for primary + non-primary.
  - **New** `"build_path_with_language/3 — sitemap honors the
    setting"` describe block covers both setting states.

`mix test` clean (806 tests, 0 failures).
`mix compile --warnings-as-errors`, `mix credo --strict`,
`mix deps.unlock --check-unused`, `mix format --check-formatted`
all clean.

`mix format` swept formatter line-wrapping changes through three
sibling files (`entity_data.ex`, `web/data_navigator.ex`,
`web/entity_form.ex`) and two test files; included in commit #3
to keep the precommit gate clean.

## Coordination

Depends on phoenix_kit core PR #552 shipping
`Languages.default_language_no_prefix?/0`. The pin in `mix.exs`
(~> 1.7) covers the next core release whenever it's cut.

## Test plan

- [ ] CI green
- [ ] Sitemap: with new core setting ON, primary-language entity
      sitemap URLs drop `/en/`
- [ ] Public URLs: with new core setting OFF (default), entity
      public URLs include `/en/` for primary (matches publishing
      and core admin URL behavior)