### PR TITLE
Fix Web.Hooks.extract_ip/1 crash on IPv6 8-tuple peer addresses (#17)

### DIFF
--- a/lib/phoenix_kit_entities/web/hooks.ex
+++ b/lib/phoenix_kit_entities/web/hooks.ex
@@ -64,7 +64,11 @@ defmodule PhoenixKitEntities.Web.Hooks do
     end
   end
 
-  defp format_ip(address) do
+  @doc false
+  # Exposed for unit tests — handles both IPv4 4-tuples and IPv6 8-tuples
+  # (incl. the IPv4-mapped `::ffff:a.b.c.d` form Docker bridge networks emit).
+  @spec format_ip(:inet.ip_address() | term()) :: String.t()
+  def format_ip(address) do
     case :inet.ntoa(address) do
       {:error, _} -> "unknown"
       chars -> to_string(chars)

--- a/lib/phoenix_kit_entities/web/hooks.ex
+++ b/lib/phoenix_kit_entities/web/hooks.ex
@@ -59,9 +59,15 @@ defmodule PhoenixKitEntities.Web.Hooks do
 
   defp extract_ip(socket) do
     case get_connect_info(socket, :peer_data) do
-      %{address: {a, b, c, d}} -> "#{a}.#{b}.#{c}.#{d}"
-      %{address: address} -> to_string(address)
+      %{address: address} when is_tuple(address) -> format_ip(address)
       _ -> "unknown"
+    end
+  end
+
+  defp format_ip(address) do
+    case :inet.ntoa(address) do
+      {:error, _} -> "unknown"
+      chars -> to_string(chars)
     end
   end
 

--- a/test/phoenix_kit_entities/web/hooks_test.exs
+++ b/test/phoenix_kit_entities/web/hooks_test.exs
@@ -1,0 +1,23 @@
+defmodule PhoenixKitEntities.Web.HooksTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixKitEntities.Web.Hooks
+
+  describe "format_ip/1" do
+    test "formats IPv4 4-tuples" do
+      assert Hooks.format_ip({172, 18, 0, 4}) == "172.18.0.4"
+      assert Hooks.format_ip({127, 0, 0, 1}) == "127.0.0.1"
+    end
+
+    test "formats IPv6 8-tuples — the regression that issue #17 reported" do
+      assert Hooks.format_ip({0, 0, 0, 0, 0, 65_535, 44_050, 4}) == "::ffff:172.18.0.4"
+      assert Hooks.format_ip({0, 0, 0, 0, 0, 0, 0, 1}) == "::1"
+    end
+
+    test "returns \"unknown\" for non-IP-tuple input rather than raising" do
+      assert Hooks.format_ip({}) == "unknown"
+      assert Hooks.format_ip({1, 2, 3}) == "unknown"
+      assert Hooks.format_ip(:bogus) == "unknown"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #17 — `PhoenixKitEntities.Web.Hooks.extract_ip/1` crashed with
`Protocol.UndefinedError: protocol String.Chars not implemented for Tuple`
on any non-4-tuple peer address, most commonly the IPv4-mapped IPv6 form
`::ffff:a.b.c.d` that Docker bridge networks behind a reverse proxy emit.
Symptom from the user side: every LiveView using `on_mount
PhoenixKitEntities.Web.Hooks` mounts → crashes → reconnects → crashes,
i.e. the admin Entities pages reconnect forever.

## Fix

Switch the address-formatting fallback to `:inet.ntoa/1`, which handles
both IPv4 4-tuples and IPv6 8-tuples and signals bad input with
`{:error, _}` (mapped to `"unknown"`). This matches the reporter's
suggested fix verbatim.

```elixir
defp extract_ip(socket) do
  case get_connect_info(socket, :peer_data) do
    %{address: address} when is_tuple(address) -> format_ip(address)
    _ -> "unknown"
  end
end

@doc false
@spec format_ip(:inet.ip_address() | term()) :: String.t()
def format_ip(address) do
  case :inet.ntoa(address) do
    {:error, _} -> "unknown"
    chars -> to_string(chars)
  end
end
```

`format_ip/1` is exposed as `@doc false` so it can be unit-tested
without a socket / DB — `extract_ip/1` remains the only production
caller.

## Tests

`test/phoenix_kit_entities/web/hooks_test.exs` covers all three branches
(no DB required, runs under `use ExUnit.Case`):

- IPv4 4-tuple → `"172.18.0.4"`, `"127.0.0.1"`
- IPv6 8-tuple → reporter's exact `{0, 0, 0, 0, 0, 65_535, 44_050, 4}`
  → `"::ffff:172.18.0.4"`, plus `{0,0,0,0,0,0,0,1}` → `"::1"`
- Bad input (`{}`, `{1,2,3}`, `:bogus`) → `"unknown"` (does not raise)

Without the fix, the IPv6 case raises and the test fails — so the test
pins the regression closed.

## Quality

- `mix format --check-formatted` ✓
- `mix compile --force --warnings-as-errors` ✓
- `mix credo --strict` ✓ (1145 mods/funs, 0 issues)
- `mix dialyzer` ✓ (0 errors)
- `mix deps.unlock --check-unused` ✓
- `mix test test/phoenix_kit_entities/web/hooks_test.exs` → 3 tests, 0 failures