### PR TITLE
Add env-gated path override for phoenix_kit deps (local dev)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,25 @@ This is a **library** (not a standalone Phoenix app). The full chain:
 - `lazy_html` (test only) — HTML parser used by `Phoenix.LiveViewTest`
   for smoke tests
 
+## Local cross-repo development
+
+`phoenix_kit` (and any sibling `phoenix_kit_*` dep) resolves from Hex by
+default. To build or test this module against a **local checkout** of a
+dependency — e.g. an unpublished core change — export `<APP>_PATH` and Mix
+swaps the Hex pin for a `path:` + `override: true` dep at resolve time:
+
+```bash
+PHOENIX_KIT_PATH=../phoenix_kit mix test     # this module against local core
+```
+
+The variable name is the dep's app name upper-cased with `_PATH` appended
+(`:phoenix_kit` -> `PHOENIX_KIT_PATH`, `:phoenix_kit_ai` ->
+`PHOENIX_KIT_AI_PATH`). Set several at once to override multiple deps. **Unset = the
+published pin**, so `mix hex.publish` and CI resolve exactly as before.
+Implemented via `pk_dep/3` in `mix.exs` — never hand-edit a `phoenix_kit*`
+dep into a `path:` tuple (a committed path dep ships a broken package); set
+the env var instead.
+
 ## Architecture
 
 This is a **PhoenixKit module** that implements the `PhoenixKit.Module`

--- a/mix.exs
+++ b/mix.exs
@@ -64,10 +64,24 @@ defmodule PhoenixKitEntities.MixProject do
     ]
   end
 
+  # phoenix_kit deps resolve from Hex by default. For cross-repo work against a
+  # local checkout, export <APP>_PATH — e.g. PHOENIX_KIT_PATH=../phoenix_kit or
+  # PHOENIX_KIT_AI_PATH=../phoenix_kit_ai. Unset => the published pin, so
+  # mix hex.publish is unaffected.
+  defp pk_dep(app, requirement, opts \\ []) do
+    env_var = String.upcase(Atom.to_string(app)) <> "_PATH"
+
+    case System.get_env(env_var) do
+      nil when opts == [] -> {app, requirement}
+      nil -> {app, requirement, opts}
+      path -> {app, [path: path, override: true] ++ opts}
+    end
+  end
+
   defp deps do
     [
       # PhoenixKit provides the Module behaviour and Settings API.
-      {:phoenix_kit, "~> 1.7"},
+      pk_dep(:phoenix_kit, "~> 1.7"),
 
       # LiveView is needed for the admin pages.
       {:phoenix_live_view, "~> 1.0"},


### PR DESCRIPTION
## What
Adds a `pk_dep/3` helper so this package's `phoenix_kit*` deps can resolve to a
**local checkout** during cross-repo development, without changing the published
dependency.

## How
`pk_dep(app, requirement, opts)` reads `<APP>_PATH` (the dep's app name
upper-cased, `+ _PATH`):

- **unset** → the existing Hex requirement, unchanged
- **set** → `{app, path: <path>, override: true} ++ opts`

So `PHOENIX_KIT_PATH=../phoenix_kit mix test` builds this module against a local
core checkout. With the var unset, `mix deps.get` / `mix hex.publish` / CI
resolve exactly as before — nothing path-based ships.

## Docs
`AGENTS.md` gains a "Local cross-repo development" section documenting the
`<APP>_PATH` convention.
